### PR TITLE
Connecting via URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,7 @@ await client.lpush('list', 'item-1', 'item-2');
 ```typescript
 // Create client (with lazy connect)
 const client = new SolidisClient({
-  host: '127.0.0.1',
-  port: 6379,
+  uri: 'redis://127.0.0.1:6379',
   lazyConnect: true
 }).extend({ get, set });
 
@@ -248,6 +247,7 @@ Solidis provides extensive configuration options:
 ```typescript
 const client = new SolidisClient({
   // Connection
+  uri: 'redis://localhost:6379',
   host: '127.0.0.1',
   port: 6379,
   useTLS: false,

--- a/sources/common/constants.ts
+++ b/sources/common/constants.ts
@@ -23,6 +23,7 @@ export const SolidisDefaultOptions: SolidisClientFrozenOptions = {
   debugMaxEntries: KB * 10,
   enableReadyCheck: true,
   host: '127.0.0.1',
+  uri: false,
   lazyConnect: false,
   maxConnectionRetries: 20,
   maxCommandsPerPipeline: 300,

--- a/sources/types/solidis.ts
+++ b/sources/types/solidis.ts
@@ -51,6 +51,7 @@ export interface SolidisClientOptions {
   debugMaxEntries?: number;
   enableReadyCheck?: boolean;
   host?: string;
+  uri?: string | URL | false;
   lazyConnect?: boolean;
   maxConnectionRetries?: number;
   maxCommandsPerPipeline?: number;


### PR DESCRIPTION
#1 

### What is changed?

Previously, only host and port were supported for connecting to the RESP server. This improvement introduces support for using a Redis URI instead.

You can use `uri` client option like this.

```typescript
const client = new SolidisClient({
  uri: 'redis://127.0.0.1:6379',
});
```