### PR TITLE
Parse authentication credentials from Redis URI

### DIFF
--- a/sources/modules/connection.ts
+++ b/sources/modules/connection.ts
@@ -308,6 +308,10 @@ export class SolidisConnection extends EventEmitter {
       const url = new URL(this.#options.uri);
 
       return {
+        authentication: {
+          username: url.username,
+          password: url.password
+        },
         host: url.hostname,
         port: url.port ? Number.parseInt(url.port) : 6379,
         useTLS: this.#options.useTLS || url.protocol === 'rediss:',


### PR DESCRIPTION
#6
## What is changed?
This pull request addresses the issue where the Redis client does not extract authentication credentials from the provided URI.

## Example
```
redis://user:secret@localhost:6379
```
The client will now correctly use `user` as the username and `secret` as the password for authentication.