### PR TITLE
fix: prevent CI concurrency group collision between caller workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,14 +1,12 @@
 name: Test
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
   workflow_call:
 
 concurrency:
-  group: test-${{ github.ref }}
+  group: test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

The `test.yaml` concurrency group was set to `test-${{ github.ref }}`, which caused `build.yaml` and `release.yaml` to cancel each other's test runs when both trigger simultaneously on a main push (e.g. when `package.json` and `sources/**` change in the same commit).

### Changes

- Removed `push: branches: [main]` from `test.yaml`'s direct triggers — on main push, tests are already invoked via `build.yaml` and `release.yaml` through `workflow_call`
- Changed concurrency group to `test-${{ github.workflow }}-${{ github.ref }}` — since `workflow_call` inherits the caller's `github.workflow`, Build and Release now run in independent groups

## Test plan

- [x] `test.yaml` triggers correctly on PRs
- [x] Build and Release workflows no longer cancel each other's test runs on main push