### PR TITLE
chore: clean sources with post coverage report

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,12 +7,6 @@ on:
       - ".github/workflows/build.yaml"
       - "sources/**"
       - "scripts/**"
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/build.yaml"
-      - "sources/**"
-      - "scripts/**"
 
 jobs:
   test:
@@ -24,8 +18,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           cache: "npm"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,8 +19,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint & type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm install
+      - run: npm run lint
+
   coverage:
     name: Coverage
+    needs: lint
     runs-on: ubuntu-latest
     services:
       server:
@@ -32,15 +45,32 @@ jobs:
           --health-interval 2s
           --health-timeout 3s
           --health-retries 30
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
       - run: npm install
       - name: Run coverage
-        run: npm run test:coverage
+        run: npm run test:coverage 2>&1 | tee /tmp/coverage.txt
         env:
           SOLIDIS_TEST_HOST: 127.0.0.1
           SOLIDIS_TEST_PORT: 6379
+      - name: Generate report
+        if: always()
+        run: npm run --silent node:ts ./scripts/workflows/coverage/report.ts /tmp/coverage.txt /tmp/coverage.md
+      - name: Job summary
+        if: always()
+        run: cat /tmp/coverage.md >> "$GITHUB_STEP_SUMMARY"
+      - name: PR comment
+        if: always() && github.event_name == 'pull_request'
+        run: >-
+          npm run node:ts ./scripts/workflows/coverage/comment.ts
+          /tmp/coverage.md
+          ${{ github.repository }}
+          ${{ github.event.pull_request.number }}
+          ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -68,10 +68,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           cache: "npm"
@@ -91,7 +91,7 @@ jobs:
           git push origin "v${{ needs.check-version.outputs.version }}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: Release v${{ needs.check-version.outputs.version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,6 @@
 name: Test
 
 on:
-  pull_request:
   workflow_dispatch:
   workflow_call:
 
@@ -14,8 +13,8 @@ jobs:
     name: Lint & type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -61,8 +60,8 @@ jobs:
           --health-timeout 3s
           --health-retries 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ node_modules
 
 # Coverage
 .coverage
-coverage
 
 # Log
 *.log

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node:ts": "node --import=./scripts/esm/register.js",
     "test": "npm run test:commands && npm run test:client",
     "test:commands": "node --import=./scripts/esm/register.js --test ./scripts/tests/commands/*.test.ts",
-    "test:client": "node --import=./scripts/esm/register.js --test --test-concurrency=1 ./scripts/tests/client/*.test.ts",
+    "test:client": "node --import=./scripts/esm/register.js --test --test-concurrency=1 ./scripts/tests/client/**/*.test.ts",
     "test:coverage": "npm run node:ts ./scripts/tests/coverage.ts",
     "web:dev": "cd ./website && npm run dev",
     "web:build": "cd ./website && npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcms-io/solidis",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Jay Lee <jay@vendit.co.kr>",
   "description": "High-performance, SOLID-structured RESP client for Redis and other RESP-compatible servers",
   "repository": {

--- a/scripts/tests/client/admin/001.server.test.ts
+++ b/scripts/tests/client/admin/001.server.test.ts
@@ -7,9 +7,13 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 
-import { closeClient, createClient, createKeyspace } from '../utils/index.ts';
+import {
+  closeClient,
+  createClient,
+  createKeyspace,
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('server', () => {
   let client: FeaturedClient;
@@ -132,7 +136,7 @@ describe('server', () => {
 
   it('constructs REPLCONF with subcommand and arguments', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/replconf.ts'
+      '../../../../sources/command/replconf.ts'
     );
 
     assert.deepStrictEqual(createCommand('GETACK', '*'), [
@@ -149,7 +153,7 @@ describe('server', () => {
 
   it('constructs MODULE LOAD with parameters', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/module.load.ts'
+      '../../../../sources/command/module.load.ts'
     );
 
     const command = createCommand('/path/to/module.so', ['arg1', 'arg2']);
@@ -165,7 +169,7 @@ describe('server', () => {
 
   it('constructs MODULE LOAD without parameters', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/module.load.ts'
+      '../../../../sources/command/module.load.ts'
     );
 
     assert.deepStrictEqual(createCommand('/path/to/module.so'), [
@@ -177,7 +181,7 @@ describe('server', () => {
 
   it('constructs MODULE LOADEX with config and parameters', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/module.loadex.ts'
+      '../../../../sources/command/module.loadex.ts'
     );
 
     const command = createCommand(
@@ -204,7 +208,7 @@ describe('server', () => {
 
   it('constructs MODULE LOADEX without config or parameters', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/module.loadex.ts'
+      '../../../../sources/command/module.loadex.ts'
     );
 
     assert.deepStrictEqual(createCommand('/path/to/module.so'), [
@@ -216,7 +220,7 @@ describe('server', () => {
 
   it('constructs MODULE UNLOAD', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/module.unload.ts'
+      '../../../../sources/command/module.unload.ts'
     );
 
     assert.deepStrictEqual(createCommand('mymodule'), [
@@ -228,7 +232,7 @@ describe('server', () => {
 
   it('parses module info with path and arguments', async () => {
     const { tryReplyToModuleInfo } = await import(
-      '../../../sources/command/utils/reply.ts'
+      '../../../../sources/command/utils/reply.ts'
     );
 
     const info = tryReplyToModuleInfo([
@@ -250,7 +254,7 @@ describe('server', () => {
 
   it('parses recursive string record from reply', async () => {
     const { tryReplyToStringRecordRecursively } = await import(
-      '../../../sources/command/utils/reply.ts'
+      '../../../../sources/command/utils/reply.ts'
     );
 
     const result = tryReplyToStringRecordRecursively([

--- a/scripts/tests/client/admin/002.server-admin.test.ts
+++ b/scripts/tests/client/admin/002.server-admin.test.ts
@@ -6,15 +6,15 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 
-import { RespError } from '../../../sources/index.ts';
+import { RespError } from '../../../../sources/index.ts';
 import {
   closeClient,
   createClient,
   createKeyspace,
   detectServerCapabilities,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient, ServerCapabilities } from '../utils/index.ts';
+import type { FeaturedClient, ServerCapabilities } from '../../utils/index.ts';
 
 describe('server-admin', () => {
   let client: FeaturedClient;
@@ -112,7 +112,6 @@ describe('server-admin', () => {
     const length = await client.slowlogLen();
 
     assert.strictEqual(typeof length, 'number');
-    /** The PING issued above with a zero threshold guarantees an entry. */
     assert.ok(length >= 1);
   });
 
@@ -185,11 +184,6 @@ describe('server-admin', () => {
       .bgsave(true)
       .catch((error: Error) => error.message);
 
-    /**
-     * The client only treats a literal `OK` as a resolved value, so the status
-     * line ("Background saving started/scheduled") surfaces through the catch;
-     * either way the message must describe the save, not an arbitrary failure.
-     */
     assert.match(result, /saving (started|scheduled)|already|in progress/i);
   });
 
@@ -244,15 +238,9 @@ describe('server-admin', () => {
     assert.strictEqual(await client.get(key), 'first');
   });
 
-  /**
-   * Shadow tests: verify command construction reaches the server without
-   * causing destructive side effects. Commands that would kill the connection
-   * (SHUTDOWN, REPLICAOF) are tested via error interception only.
-   */
-
   it('verifies SHUTDOWN command construction without sending', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/shutdown.ts'
+      '../../../../sources/command/shutdown.ts'
     );
 
     assert.deepStrictEqual(createCommand(), ['SHUTDOWN']);
@@ -281,7 +269,9 @@ describe('server-admin', () => {
   });
 
   it('verifies HELLO command construction with all option branches', async () => {
-    const { createCommand } = await import('../../../sources/command/hello.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/hello.ts'
+    );
 
     assert.deepStrictEqual(createCommand('RESP3'), ['HELLO', '3']);
     assert.deepStrictEqual(createCommand('RESP2'), ['HELLO', '2']);
@@ -320,7 +310,7 @@ describe('server-admin', () => {
 
   it('verifies SORT_RO command construction with all options', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/sort.ro.ts'
+      '../../../../sources/command/sort.ro.ts'
     );
 
     assert.deepStrictEqual(createCommand('key'), ['SORT_RO', 'key']);
@@ -384,7 +374,7 @@ describe('server-admin', () => {
 
   it('verifies FUNCTION LIST command construction with options', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/function.list.ts'
+      '../../../../sources/command/function.list.ts'
     );
 
     assert.deepStrictEqual(createCommand(), ['FUNCTION', 'LIST']);
@@ -410,7 +400,7 @@ describe('server-admin', () => {
 
   it('verifies FUNCTION RESTORE command construction with options', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/function.restore.ts'
+      '../../../../sources/command/function.restore.ts'
     );
 
     const dump = 'fakebinarydump';
@@ -436,7 +426,7 @@ describe('server-admin', () => {
 
   it('verifies MIGRATE command construction with all options', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/migrate.ts'
+      '../../../../sources/command/migrate.ts'
     );
 
     assert.deepStrictEqual(createCommand('10.0.0.1', 6380, 'mykey', 0, 5000), [
@@ -511,7 +501,7 @@ describe('server-admin', () => {
 
   it('verifies FAILOVER command construction with all options', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/failover.ts'
+      '../../../../sources/command/failover.ts'
     );
 
     assert.deepStrictEqual(createCommand(), ['FAILOVER']);
@@ -564,11 +554,6 @@ describe('server-admin', () => {
   it('executes DEBUG SLEEP 0 without blocking', async () => {
     const [[reply]] = await client.send([['DEBUG', 'SLEEP', '0']]);
 
-    /**
-     * DEBUG is gated behind `enable-debug-command` on hardened builds (Redis
-     * Stack), so the reply is either OK or a specific "not allowed" RespError —
-     * never an unrelated value.
-     */
     if (reply instanceof RespError) {
       assert.match(`${reply.message}`, /DEBUG|not allowed|unknown/i);
       return;
@@ -580,10 +565,6 @@ describe('server-admin', () => {
   it('rewrites the config file with CONFIG REWRITE', async () => {
     const result = await client.configRewrite().catch((error: Error) => error);
 
-    /**
-     * Succeeds with OK when started from a config file; otherwise it must fail
-     * with the specific "running without a config file" error.
-     */
     if (result instanceof Error) {
       assert.match(`${result.message}`, /config file/i);
       return;
@@ -607,10 +588,6 @@ describe('server-admin', () => {
 
     const result = await client.objectFreq(key).catch((error: Error) => error);
 
-    /**
-     * OBJECT FREQ is only valid under an LFU maxmemory-policy; with the default
-     * policy it must reject with the LFU-specific error rather than any error.
-     */
     if (result instanceof Error) {
       assert.match(`${result.message}`, /LFU|maxmemory/i);
       return;
@@ -683,7 +660,6 @@ describe('server-admin', () => {
     const histograms = await client.latencyHistogram('ping');
 
     assert.strictEqual(typeof histograms, 'object');
-    /** The 10 pings above must be recorded in the ping histogram. */
     assert.ok('ping' in histograms, 'expected a ping histogram entry');
     assert.strictEqual(typeof histograms.ping.calls, 'number');
     assert.ok(histograms.ping.calls >= 10);
@@ -696,7 +672,6 @@ describe('server-admin', () => {
       return;
     }
 
-    /** With no function running, FUNCTION KILL must reject with NOTBUSY. */
     await assert.rejects(
       () => client.functionKill(),
       (error: Error) => /NOTBUSY|No scripts|not running/i.test(error.message),
@@ -708,7 +683,9 @@ describe('server-admin', () => {
   });
 
   it('verifies AUTH command construction without sending', async () => {
-    const { createCommand } = await import('../../../sources/command/auth.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/auth.ts'
+    );
 
     assert.deepStrictEqual(createCommand('user', 'pass'), [
       'AUTH',
@@ -724,7 +701,7 @@ describe('server-admin', () => {
 
   it('verifies REPLICAOF command construction without sending', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/replicaof.ts'
+      '../../../../sources/command/replicaof.ts'
     );
 
     assert.strictEqual(createCommand('127.0.0.1', 6379)[0], 'REPLICAOF');
@@ -733,13 +710,17 @@ describe('server-admin', () => {
   });
 
   it('verifies SYNC command construction', async () => {
-    const { createCommand } = await import('../../../sources/command/sync.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/sync.ts'
+    );
 
     assert.deepStrictEqual(createCommand(), ['SYNC']);
   });
 
   it('verifies RESET command construction', async () => {
-    const { createCommand } = await import('../../../sources/command/reset.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/reset.ts'
+    );
 
     assert.deepStrictEqual(createCommand(), ['RESET']);
   });
@@ -752,7 +733,7 @@ describe('server-admin', () => {
 
   it('verifies MODULE LOAD command construction', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/module.load.ts'
+      '../../../../sources/command/module.load.ts'
     );
 
     assert.deepStrictEqual(createCommand('/path/to/module.so'), [
@@ -764,7 +745,7 @@ describe('server-admin', () => {
 
   it('verifies MODULE UNLOAD command construction', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/module.unload.ts'
+      '../../../../sources/command/module.unload.ts'
     );
 
     assert.deepStrictEqual(createCommand('mymodule'), [
@@ -776,7 +757,7 @@ describe('server-admin', () => {
 
   it('verifies MODULE LOADEX command construction', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/module.loadex.ts'
+      '../../../../sources/command/module.loadex.ts'
     );
 
     const command = createCommand('/path/to/module.so');
@@ -789,7 +770,6 @@ describe('server-admin', () => {
   it('resets latency events by name', async () => {
     const reset = await client.latencyReset(['command']);
 
-    /** LATENCY RESET returns the number of event time series it cleared. */
     assert.strictEqual(typeof reset, 'number');
     assert.ok(reset >= 0);
   });
@@ -833,7 +813,9 @@ describe('server-admin', () => {
   });
 
   it('verifies SORT command construction with all options', async () => {
-    const { createCommand } = await import('../../../sources/command/sort.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/sort.ts'
+    );
 
     assert.deepStrictEqual(createCommand('key'), ['SORT', 'key']);
 
@@ -906,7 +888,7 @@ describe('server-admin', () => {
 
   it('verifies RESTORE command construction with all options', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/restore.ts'
+      '../../../../sources/command/restore.ts'
     );
 
     const base = createCommand('key', 0, 'dump');
@@ -949,7 +931,9 @@ describe('server-admin', () => {
   });
 
   it('verifies GETEX command construction with all TTL modes', async () => {
-    const { createCommand } = await import('../../../sources/command/getex.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/getex.ts'
+    );
 
     assert.deepStrictEqual(createCommand('key'), ['GETEX', 'key']);
 
@@ -983,7 +967,9 @@ describe('server-admin', () => {
   });
 
   it('verifies LCS command construction with all options', async () => {
-    const { createCommand } = await import('../../../sources/command/lcs.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/lcs.ts'
+    );
 
     assert.deepStrictEqual(createCommand('a', 'b'), ['LCS', 'a', 'b']);
 
@@ -1023,7 +1009,7 @@ describe('server-admin', () => {
 
   it('verifies CLIENT TRACKING command construction with all options', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/client.tracking.ts'
+      '../../../../sources/command/client.tracking.ts'
     );
 
     assert.deepStrictEqual(createCommand('ON'), ['CLIENT', 'TRACKING', 'ON']);
@@ -1093,7 +1079,9 @@ describe('server-admin', () => {
   });
 
   it('verifies LPOS command construction with all options', async () => {
-    const { createCommand } = await import('../../../sources/command/lpos.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/lpos.ts'
+    );
 
     assert.deepStrictEqual(createCommand('key', 'el'), ['LPOS', 'key', 'el']);
 
@@ -1129,7 +1117,7 @@ describe('server-admin', () => {
 
   it('verifies LATENCY HISTOGRAM command construction', async () => {
     const { createCommand } = await import(
-      '../../../sources/command/latency.histogram.ts'
+      '../../../../sources/command/latency.histogram.ts'
     );
 
     assert.deepStrictEqual(createCommand('ping'), [

--- a/scripts/tests/client/admin/003.client-commands.test.ts
+++ b/scripts/tests/client/admin/003.client-commands.test.ts
@@ -12,9 +12,9 @@ import {
   createKeyspace,
   detectServerCapabilities,
   waitFor,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient, ServerCapabilities } from '../utils/index.ts';
+import type { FeaturedClient, ServerCapabilities } from '../../utils/index.ts';
 
 describe('client-commands', () => {
   let client: FeaturedClient;
@@ -273,7 +273,6 @@ describe('client-commands', () => {
 
   it('unblocks a client by id', async () => {
     const id = await client.clientId();
-    /** The client is not blocked, so UNBLOCK reports 0 (nothing unblocked). */
     assert.strictEqual(await client.clientUnblock(id), 0);
   });
 
@@ -307,7 +306,6 @@ describe('client-commands', () => {
 
       const settlement = await pending;
 
-      /** UNBLOCK ... ERROR forces the blocked BLPOP to reject. */
       assert.strictEqual(settlement.rejected, true);
       assert.ok(settlement.error instanceof Error);
     } finally {
@@ -316,7 +314,6 @@ describe('client-commands', () => {
   });
 
   it('toggles client caching mode', async () => {
-    /** CLIENT CACHING is only valid in OPTIN/OPTOUT tracking mode. */
     await assert.rejects(
       () => client.clientCaching('YES'),
       (error: Error) => /tracking mode|OPTIN|OPTOUT/i.test(error.message),
@@ -420,7 +417,6 @@ describe('client-commands', () => {
   });
 
   it('switches client reply mode', async () => {
-    /** CLIENT REPLY ON synchronously acknowledges with OK. */
     assert.strictEqual(await client.clientReply('ON'), 'OK');
   });
 
@@ -449,7 +445,9 @@ describe('client-commands', () => {
   });
 
   it('constructs AUTH with single password argument', async () => {
-    const { createCommand } = await import('../../../sources/command/auth.ts');
+    const { createCommand } = await import(
+      '../../../../sources/command/auth.ts'
+    );
 
     const command = createCommand('mypassword');
 

--- a/scripts/tests/client/core/001.connection.test.ts
+++ b/scripts/tests/client/core/001.connection.test.ts
@@ -1,24 +1,18 @@
-/**
- * Connection lifecycle, handshake, and reconnection behaviour.
- *
- * These tests exercise the client independently of any single data command:
- * lazy versus eager connect, event ordering, protocol negotiation, database
- * selection, and graceful teardown.
- */
+/** Connection lifecycle, handshake, and reconnection behaviour. */
 
 import assert from 'node:assert/strict';
 import { after, describe, it } from 'node:test';
 
-import { SolidisFeaturedClient } from '../../../sources/client/featured.ts';
-import { SolidisClientError } from '../../../sources/index.ts';
+import { SolidisFeaturedClient } from '../../../../sources/client/featured.ts';
+import { SolidisClientError } from '../../../../sources/index.ts';
 import {
   buildClientOptions,
   closeClient,
   createClient,
   delay,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('connection', () => {
   const trackedClients: FeaturedClient[] = [];
@@ -115,7 +109,6 @@ describe('connection', () => {
 
     client.quit();
 
-    /** Wait for the actual teardown signal rather than a no-op predicate. */
     await ended;
 
     await assert.rejects(

--- a/scripts/tests/client/core/002.errors.test.ts
+++ b/scripts/tests/client/core/002.errors.test.ts
@@ -6,7 +6,7 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 
-import { SolidisFeaturedClient } from '../../../sources/client/featured.ts';
+import { SolidisFeaturedClient } from '../../../../sources/client/featured.ts';
 import {
   RespError,
   SolidisClientError,
@@ -21,15 +21,15 @@ import {
   wrapWithSolidisClientError,
   wrapWithSolidisConnectionError,
   wrapWithSolidisRequesterError,
-} from '../../../sources/index.ts';
+} from '../../../../sources/index.ts';
 import {
   buildClientOptions,
   closeClient,
   createClient,
   createKeyspace,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('errors', () => {
   let client: FeaturedClient;

--- a/scripts/tests/client/core/003.blocking.test.ts
+++ b/scripts/tests/client/core/003.blocking.test.ts
@@ -1,11 +1,4 @@
-/**
- * Blocking list and sorted-set commands: BLPOP, BRPOP, BLMOVE, BLMPOP,
- * BRPOPLPUSH, BZPOPMIN, BZPOPMAX, and BZMPOP.
- *
- * Each test pre-populates data so the blocking command returns immediately
- * (timeout = 0) rather than relying on asynchronous pushes from a second
- * client.
- */
+/** Blocking list and sorted-set commands. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
@@ -15,9 +8,9 @@ import {
   createClient,
   createKeyspace,
   detectServerCapabilities,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('blocking', () => {
   let client: FeaturedClient;

--- a/scripts/tests/client/core/004.lifecycle-edge.test.ts
+++ b/scripts/tests/client/core/004.lifecycle-edge.test.ts
@@ -1,30 +1,22 @@
-/**
- * Connection / client lifecycle edge branches.
- *
- * Targets the less-travelled paths in the connection and client modules: the
- * TLS socket constructor, RESP3 negotiation, lazy connect, the
- * autoReconnect-disabled close path, repeated (idempotent) fault recovery, and
- * the debug wiring. These are the branches that ordinary command tests never
- * reach.
- */
+/** Connection/client lifecycle edge branches (TLS, RESP3, lazy connect, no-reconnect, debug). */
 
 import assert from 'node:assert/strict';
 import { after, describe, it } from 'node:test';
 
-import { SolidisFeaturedClient } from '../../../sources/client/featured.ts';
+import { SolidisFeaturedClient } from '../../../../sources/client/featured.ts';
 import {
   SolidisClientError,
   SolidisConnectionError,
-} from '../../../sources/index.ts';
+} from '../../../../sources/index.ts';
 import {
   buildClientOptions,
   closeClient,
   createClient,
   delay,
   waitFor,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('lifecycle-edge', () => {
   const tracked: FeaturedClient[] = [];
@@ -46,7 +38,6 @@ describe('lifecycle-edge', () => {
     const key = `solidis:test:resp3:${Date.now()}`;
     await client.hset(key, 'a', '1');
 
-    /** RESP3 returns a map for HGETALL; the client normalises it to an object. */
     const all = await client.hgetall(key);
     assert.strictEqual(all.a, '1');
 
@@ -58,14 +49,13 @@ describe('lifecycle-edge', () => {
       buildClientOptions({
         useTLS: true,
         lazyConnect: true,
-        connectionTimeout: 1500,
+        connectionTimeout: 500,
         maxConnectionRetries: 0,
       }),
     );
 
     client.on('error', () => {});
 
-    /** The point is to exercise tls.connect(); the handshake is expected to fail. */
     await assert.rejects(
       () => client.connect(),
       (error: Error) =>
@@ -83,7 +73,6 @@ describe('lifecycle-edge', () => {
 
     client.on('error', () => {});
 
-    /** No eager connection; the command itself triggers connect(). */
     assert.strictEqual(await client.ping(), 'PONG');
   });
 
@@ -100,18 +89,9 @@ describe('lifecycle-edge', () => {
     const clientId = await client.clientId();
     const killer = track(await createClient());
 
-    /**
-     * Killing the connection drives the close handler's autoReconnect-disabled
-     * branch (it emits 'closed' and returns without scheduling a reconnect).
-     */
     await killer.clientKill(clientId);
-    await delay(150);
+    await delay(80);
 
-    /**
-     * With autoReconnect off the socket stays down until a command forces a
-     * manual reconnect via connect(); the client then recovers on demand and
-     * the previously written value is still durable.
-     */
     assert.strictEqual(await client.get(key), 'v');
   });
 
@@ -121,6 +101,7 @@ describe('lifecycle-edge', () => {
         autoReconnect: true,
         maxConnectionRetries: 10,
         connectionRetryDelay: 25,
+        connectionTimeout: 500,
       }),
     );
 
@@ -131,8 +112,7 @@ describe('lifecycle-edge', () => {
 
     const killer = track(await createClient());
 
-    /** Two kills in quick succession drive the recovery guard's early return. */
-    for (let round = 0; round < 3; round += 1) {
+    for (let round = 0; round < 2; round += 1) {
       const id = await client.clientId().catch(() => null);
 
       if (id !== null) {
@@ -148,7 +128,7 @@ describe('lifecycle-edge', () => {
             return false;
           }
         },
-        { timeout: 3000, interval: 25, description: 'recovered' },
+        { timeout: 2000, interval: 25, description: 'recovered' },
       );
     }
 

--- a/scripts/tests/client/fault/001.recovery-state.test.ts
+++ b/scripts/tests/client/fault/001.recovery-state.test.ts
@@ -1,13 +1,4 @@
-/**
- * Reconnection STATE recovery.
- *
- * Auto-reconnect alone is not enough: after the socket comes back the client
- * must restore the session state the caller established before the fault —
- * specifically the selected database and any active subscriptions (governed by
- * the `autoRecovery` option). These tests force a disconnect with CLIENT KILL
- * and assert the recovered connection behaves as if nothing happened, and that
- * disabling a recovery flag is genuinely honoured.
- */
+/** Reconnection state recovery: database re-selection and subscription restoration. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
@@ -17,9 +8,9 @@ import {
   createClient,
   createKeyspace,
   waitFor,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('recovery-state', () => {
   let killer: FeaturedClient;
@@ -33,11 +24,6 @@ describe('recovery-state', () => {
     await closeClient(killer);
   });
 
-  /**
-   * Force-closes `target`'s server-side connection and waits for it to become
-   * ready again. The client id is taken as a parameter because a subscribed
-   * RESP2 connection cannot issue CLIENT ID itself.
-   */
   const forceReconnect = async (
     target: FeaturedClient,
     clientId: number,
@@ -53,7 +39,8 @@ describe('recovery-state', () => {
       database: 3,
       autoReconnect: true,
       maxConnectionRetries: 5,
-      connectionRetryDelay: 50,
+      connectionRetryDelay: 25,
+      connectionTimeout: 500,
     });
 
     client.on('error', () => {});
@@ -65,17 +52,11 @@ describe('recovery-state', () => {
 
       await client.set(key, 'on-db-3');
 
-      /** Sanity: the write landed on db 3, invisible to a db 0 connection. */
       assert.strictEqual(await probe.get(key), null);
       assert.match(await client.clientInfo(), /\bdb=3\b/);
 
       await forceReconnect(client, await client.clientId());
 
-      /**
-       * The reconnected connection must be back on db 3. CLIENT INFO is checked
-       * directly (rather than relying on a key surviving) so the assertion is
-       * immune to unrelated global writes on the shared server.
-       */
       assert.match(await client.clientInfo(), /\bdb=3\b/);
 
       const afterKey = keyspace.key('db', 'after');
@@ -96,7 +77,8 @@ describe('recovery-state', () => {
     const subscriber = await createClient({
       autoReconnect: true,
       maxConnectionRetries: 5,
-      connectionRetryDelay: 50,
+      connectionRetryDelay: 25,
+      connectionTimeout: 500,
     });
 
     subscriber.on('error', () => {});
@@ -112,7 +94,6 @@ describe('recovery-state', () => {
     });
 
     try {
-      /** Capture the id before subscribing; CLIENT ID is blocked once subscribed. */
       const subscriberId = await subscriber.clientId();
 
       await subscriber.subscribe(channel);
@@ -129,13 +110,11 @@ describe('recovery-state', () => {
 
       await forceReconnect(subscriber, subscriberId);
 
-      /** After reconnect the subscription must be re-established server-side. */
       await waitFor(
         async () => (await publisher.pubsubNumsub([channel]))[channel] === 1,
         { timeout: 3000, description: 'subscription restored' },
       );
 
-      /** And messages must flow to the same handler again. */
       await waitFor(
         async () => {
           await publisher.publish(channel, 'after');
@@ -160,7 +139,8 @@ describe('recovery-state', () => {
     const subscriber = await createClient({
       autoReconnect: true,
       maxConnectionRetries: 5,
-      connectionRetryDelay: 50,
+      connectionRetryDelay: 25,
+      connectionTimeout: 500,
       autoRecovery: {
         database: true,
         subscribe: false,
@@ -186,10 +166,6 @@ describe('recovery-state', () => {
 
       await forceReconnect(subscriber, subscriberId);
 
-      /**
-       * With re-subscription disabled the reconnected connection must NOT be
-       * subscribed; the server should report zero subscribers for the channel.
-       */
       await waitFor(
         async () => {
           try {

--- a/scripts/tests/client/fault/002.stress-recovery.test.ts
+++ b/scripts/tests/client/fault/002.stress-recovery.test.ts
@@ -1,26 +1,4 @@
-/**
- * Fault-recovery STRESS with explicit loss accounting.
- *
- * This suite repeatedly breaks the connection in the nastiest ways and measures
- * exactly how much in-flight work is lost, then asserts the invariants that
- * must hold no matter how violent the fault:
- *
- *   - no command promise is ever left unsettled (resolved + rejected == issued);
- *   - every write the client acknowledged as resolved is durable on the server
- *     (persisted >= resolved);
- *   - the client returns to full health afterwards.
- *
- * It also reports the observed loss rate so a regression can be quantified.
- *
- * KNOWN BUG (documented as a `todo` reproduction below): when a command is
- * abandoned by a client-side `commandTimeout`, `recoveryFromFault` resets the
- * requester but leaves the socket open. The server's (late) reply for the
- * abandoned command is then mis-attributed to the next command issued on the
- * same connection, silently desynchronising it. This is reproduced
- * deterministically with a blocking command so the maintainer can decide on a
- * fix (drop+reconnect the socket on fault, or discard the exact number of
- * outstanding replies) without the regression failing CI today.
- */
+/** Fault-recovery stress with explicit loss accounting. */
 
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
@@ -33,9 +11,9 @@ import {
   delay,
   range,
   waitFor,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('stress-recovery', () => {
   let killer: FeaturedClient;
@@ -67,12 +45,13 @@ describe('stress-recovery', () => {
       autoReconnect: true,
       maxConnectionRetries: 20,
       connectionRetryDelay: 25,
+      connectionTimeout: 500,
     });
 
     client.on('error', () => {});
 
-    const rounds = 10;
-    const perRound = 700;
+    const rounds = 3;
+    const perRound = 400;
 
     let resolved = 0;
     let rejected = 0;
@@ -97,11 +76,6 @@ describe('stress-recovery', () => {
           });
       });
 
-      /**
-       * Let part of the batch acknowledge, then kill while the rest is still
-       * draining — this exercises both the durable-ack invariant (for resolved
-       * writes) and the rejection path (for in-flight ones).
-       */
       await delay(5);
       await killer.clientKill(clientId).catch(() => {});
 
@@ -111,10 +85,16 @@ describe('stress-recovery', () => {
     await waitUntilReady(client);
 
     let persisted = 0;
+    const batchSize = 100;
 
-    for (const key of keys) {
-      if ((await client.get(key)) !== null) {
-        persisted += 1;
+    for (let index = 0; index < keys.length; index += batchSize) {
+      const batch = keys.slice(index, index + batchSize);
+      const values = await client.mget(...batch);
+
+      for (const value of values) {
+        if (value !== null) {
+          persisted += 1;
+        }
       }
     }
 
@@ -128,20 +108,17 @@ describe('stress-recovery', () => {
         `lostAck(applied-but-not-acked)=${lostButApplied}`,
     );
 
-    /** Invariant 1: no command is silently swallowed. */
     assert.strictEqual(
       resolved + rejected,
       total,
       'every issued command must settle exactly once',
     );
 
-    /** Invariant 2: an acknowledged write is always durable. */
     assert.ok(
       persisted >= resolved,
       `acknowledged writes must be durable: persisted=${persisted} < resolved=${resolved}`,
     );
 
-    /** Invariant 3: the client is fully usable after the abuse. */
     assert.strictEqual(await client.set(keyspace.key('final'), 'ok'), 'OK');
     assert.strictEqual(await client.get(keyspace.key('final')), 'ok');
 
@@ -154,11 +131,12 @@ describe('stress-recovery', () => {
       autoReconnect: true,
       maxConnectionRetries: 20,
       connectionRetryDelay: 20,
+      connectionTimeout: 500,
     });
 
     client.on('error', () => {});
 
-    const total = 5000;
+    const total = 2000;
     let correct = 0;
     let wrong = 0;
     let rejected = 0;
@@ -196,7 +174,6 @@ describe('stress-recovery', () => {
       console.error(`  wrong samples: ${wrongSamples.join(' | ')}`);
     }
 
-    /** No resolved command may ever carry another command's reply. */
     assert.strictEqual(
       wrong,
       0,
@@ -204,7 +181,6 @@ describe('stress-recovery', () => {
     );
     assert.strictEqual(correct + rejected, total);
 
-    /** The connection must come back to full health after the storm. */
     await waitUntilReady(client);
     assert.strictEqual(await client.echo('post-storm'), 'post-storm');
 
@@ -216,14 +192,14 @@ describe('stress-recovery', () => {
       autoReconnect: true,
       maxConnectionRetries: 20,
       connectionRetryDelay: 25,
+      connectionTimeout: 500,
     });
 
     client.on('error', () => {});
 
     const clientId = await client.clientId();
 
-    /** One enormous pipeline; killing it must settle the whole thing. */
-    const commands = range(20000).map((index) => [
+    const commands = range(5000).map((index) => [
       'SET',
       keyspace.key('giant', index),
       `${index}`,
@@ -241,7 +217,6 @@ describe('stress-recovery', () => {
 
     console.log(`[stress-recovery] giant-pipeline kill outcome=${outcome}`);
 
-    /** Whatever happens, the promise settles and the client recovers. */
     assert.ok(outcome === 'resolved' || outcome === 'rejected');
 
     await waitUntilReady(client);
@@ -253,18 +228,12 @@ describe('stress-recovery', () => {
     await closeClient(client);
   });
 
-  /**
-   * Regression for the command-timeout desync bug: a command abandoned by
-   * `commandTimeout` leaves its (late) reply on the still-open socket, and that
-   * reply must be discarded rather than handed to the next command. The fix
-   * counts the outstanding replies during recovery and drops exactly that many.
-   */
   it('does not mis-attribute a stale reply after a command timeout', async () => {
     const victim = await createClient({
-      commandTimeout: 150,
+      commandTimeout: 80,
       autoReconnect: true,
       maxConnectionRetries: 5,
-      connectionRetryDelay: 50,
+      connectionRetryDelay: 30,
     });
 
     victim.on('error', () => {});
@@ -273,30 +242,26 @@ describe('stress-recovery', () => {
     const key = keyspace.key('stale', randomUUID());
 
     try {
-      /** BLPOP blocks; the client abandons it on timeout but the server does not. */
       const blocked = victim
         .blpop([key], 0)
         .then(() => 'resolved')
         .catch(() => 'rejected');
 
-      await delay(300);
+      await delay(120);
 
-      /** Issue a fresh command so it is in-flight when the stale reply lands. */
       const echoPromise = victim
         .echo('FRESH')
         .then((value) => value)
         .catch((error: Error) => `THREW:${error.message}`);
 
-      await delay(30);
+      await delay(20);
 
-      /** Release BLPOP: server emits [key, payload] then the ECHO reply. */
       await pusher.rpush(key, 'STALE-PAYLOAD');
 
       const echoed = await echoPromise;
 
       await blocked;
 
-      /** The fresh command must get its own reply, never the stale BLPOP one. */
       assert.strictEqual(echoed, 'FRESH');
     } finally {
       await closeClient(pusher);

--- a/scripts/tests/client/resilience/001.debug-requester.test.ts
+++ b/scripts/tests/client/resilience/001.debug-requester.test.ts
@@ -7,16 +7,16 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
 
-import { RespError } from '../../../sources/index.ts';
+import { RespError } from '../../../../sources/index.ts';
 import {
   closeClient,
   createClient,
   createKeyspace,
   delay,
   waitFor,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('debug-requester', () => {
   let client: FeaturedClient;
@@ -33,7 +33,7 @@ describe('debug-requester', () => {
   describe('debug memory', () => {
     it('writes entries and respects max capacity', async () => {
       const { SolidisDebugMemory } = await import(
-        '../../../sources/modules/debug.ts'
+        '../../../../sources/modules/debug.ts'
       );
 
       const memory = new SolidisDebugMemory(3);
@@ -52,7 +52,7 @@ describe('debug-requester', () => {
 
     it('clears logs', async () => {
       const { SolidisDebugMemory } = await import(
-        '../../../sources/modules/debug.ts'
+        '../../../../sources/modules/debug.ts'
       );
 
       const memory = new SolidisDebugMemory(10);
@@ -68,7 +68,7 @@ describe('debug-requester', () => {
 
     it('adds timestamp when not provided', async () => {
       const { SolidisDebugMemory } = await import(
-        '../../../sources/modules/debug.ts'
+        '../../../../sources/modules/debug.ts'
       );
 
       const memory = new SolidisDebugMemory(10);
@@ -83,7 +83,7 @@ describe('debug-requester', () => {
 
     it('emits pushed event on write', async () => {
       const { SolidisDebugMemory } = await import(
-        '../../../sources/modules/debug.ts'
+        '../../../../sources/modules/debug.ts'
       );
 
       const memory = new SolidisDebugMemory(10);
@@ -112,7 +112,7 @@ describe('debug-requester', () => {
 
     it('transforms debug log with data field', async () => {
       const { SolidisDebugTransform } = await import(
-        '../../../sources/modules/debug.ts'
+        '../../../../sources/modules/debug.ts'
       );
 
       const transform = new SolidisDebugTransform();
@@ -133,7 +133,7 @@ describe('debug-requester', () => {
 
     it('transforms debug log without data field', async () => {
       const { SolidisDebugTransform } = await import(
-        '../../../sources/modules/debug.ts'
+        '../../../../sources/modules/debug.ts'
       );
 
       const transform = new SolidisDebugTransform();
@@ -156,7 +156,7 @@ describe('debug-requester', () => {
   describe('debug handle generator', () => {
     it('returns undefined when no debug memory provided', async () => {
       const { generateDebugHandle } = await import(
-        '../../../sources/common/utils/debug.ts'
+        '../../../../sources/common/utils/debug.ts'
       );
 
       const handle = generateDebugHandle(undefined);
@@ -166,10 +166,10 @@ describe('debug-requester', () => {
 
     it('returns a function that writes to debug memory', async () => {
       const { generateDebugHandle } = await import(
-        '../../../sources/common/utils/debug.ts'
+        '../../../../sources/common/utils/debug.ts'
       );
       const { SolidisDebugMemory } = await import(
-        '../../../sources/modules/debug.ts'
+        '../../../../sources/modules/debug.ts'
       );
 
       const memory = new SolidisDebugMemory(10);
@@ -196,7 +196,7 @@ describe('debug-requester', () => {
 
       try {
         const { SolidisDebugMemory } = await import(
-          '../../../sources/modules/debug.ts'
+          '../../../../sources/modules/debug.ts'
         );
 
         const memory = new SolidisDebugMemory(10);
@@ -220,7 +220,7 @@ describe('debug-requester', () => {
   describe('debug command', () => {
     it('constructs DEBUG command with subcommand and parameters', async () => {
       const { createCommand } = await import(
-        '../../../sources/command/debug.ts'
+        '../../../../sources/command/debug.ts'
       );
 
       const command = createCommand('SLEEP', '0');
@@ -231,11 +231,6 @@ describe('debug-requester', () => {
     it('executes DEBUG SLEEP 0 without error', async () => {
       const reply = await client.debug('SLEEP', '0');
 
-      /**
-       * DEBUG may be disabled (`enable-debug-command`); in that case the client
-       * surfaces the inline RespError rather than throwing. Either way the
-       * reply is a known value, never undefined or garbage.
-       */
       if (reply instanceof RespError) {
         assert.match(`${reply.message}`, /DEBUG|not allowed|unknown/i);
         return;
@@ -271,7 +266,8 @@ describe('debug-requester', () => {
     it('recovers after fault and accepts new commands', async () => {
       const recoveryClient = await createClient({
         maxConnectionRetries: 5,
-        connectionRetryDelay: 50,
+        connectionRetryDelay: 25,
+        connectionTimeout: 500,
         autoReconnect: true,
       });
 
@@ -281,7 +277,6 @@ describe('debug-requester', () => {
 
       await recoveryClient.set(key, 'before');
 
-      /** Inject a real fault: another client force-closes this connection. */
       const clientId = await recoveryClient.clientId();
       const killer = await createClient();
 
@@ -293,7 +288,6 @@ describe('debug-requester', () => {
       await reconnected;
       await closeClient(killer);
 
-      /** The reconnected client must serve new commands and see persisted data. */
       assert.strictEqual(await recoveryClient.get(key), 'before');
       assert.strictEqual(await recoveryClient.set(key, 'after'), 'OK');
       assert.strictEqual(await recoveryClient.get(key), 'after');
@@ -363,10 +357,6 @@ describe('debug-requester', () => {
 
       await strictClient.set(key, 'hello');
 
-      /**
-       * With rejectOnPartialPipelineError the inline error reply is surfaced
-       * directly as the rejection, so the caller sees the original RespError.
-       */
       await assert.rejects(
         () => strictClient.incr(key),
         (error: Error) =>
@@ -408,7 +398,8 @@ describe('debug-requester', () => {
       const faultClient = await createClient({
         autoReconnect: true,
         maxConnectionRetries: 3,
-        connectionRetryDelay: 50,
+        connectionRetryDelay: 25,
+        connectionTimeout: 500,
       });
 
       faultClient.on('error', () => {});
@@ -422,30 +413,20 @@ describe('debug-requester', () => {
 
       const killerClient = await createClient();
 
-      /**
-       * A BLPOP on an empty list is guaranteed to still be in-flight when the
-       * connection is killed, so its settlement deterministically exercises the
-       * fault path instead of racing a fast localhost reply.
-       */
       const pendingSettled = faultClient
         .blpop([blockKey], 0)
         .then(() => ({ rejected: false, error: undefined as unknown }))
         .catch((error: unknown) => ({ rejected: true, error }));
 
-      await delay(50);
+      await delay(30);
 
       await killerClient.clientKill(clientId);
 
       const settlement = await pendingSettled;
 
-      /**
-       * A command interrupted by a socket fault must reject (it can never be
-       * silently dropped); the matching reply was lost with the old session.
-       */
       assert.strictEqual(settlement.rejected, true);
       assert.ok(settlement.error instanceof Error);
 
-      /** Poll until the auto-reconnect has restored a usable connection. */
       await waitFor(
         async () => {
           try {
@@ -454,7 +435,7 @@ describe('debug-requester', () => {
             return false;
           }
         },
-        { timeout: 3000, interval: 50, description: 'reconnect after fault' },
+        { timeout: 2000, interval: 30, description: 'reconnect after fault' },
       );
 
       assert.strictEqual(await faultClient.set(key, 'recovered'), 'OK');
@@ -470,7 +451,8 @@ describe('debug-requester', () => {
       const recoveryClient = await createClient({
         autoReconnect: true,
         maxConnectionRetries: 3,
-        connectionRetryDelay: 50,
+        connectionRetryDelay: 25,
+        connectionTimeout: 500,
       });
 
       recoveryClient.on('error', () => {});
@@ -484,7 +466,7 @@ describe('debug-requester', () => {
 
       await killerClient.clientKill(clientId);
 
-      await delay(500);
+      await delay(150);
 
       const value = await recoveryClient.get(key);
 

--- a/scripts/tests/client/resilience/002.fragility.test.ts
+++ b/scripts/tests/client/resilience/002.fragility.test.ts
@@ -1,29 +1,14 @@
-/**
- * Fragility & recovery.
- *
- * Three angles, all aimed at "what happens when things go wrong":
- *
- *  1. Hostile *payloads* sent to a real server (empty frames, binary bytes,
- *     bogus command names, wrong arity) must never corrupt the client's
- *     pipeline — a normal command issued right after must still work.
- *  2. Hostile *bytes from the server* (unknown RESP prefixes, truncated frames,
- *     unsolicited replies, abrupt socket loss) are simulated with a scriptable
- *     mock server to confirm the client fails loudly and stays correlated.
- *  3. Faults that break the connection mid-flight reject the in-flight work
- *     deterministically, and the client either recovers (auto-reconnect) or
- *     stays permanently closed (after quit) — with explicit accounting of how
- *     much in-flight work is lost across the fault boundary.
- */
+/** Fragility & recovery: hostile payloads, protocol corruption, and fault accounting. */
 
 import assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
 
-import { SolidisFeaturedClient } from '../../../sources/client/featured.ts';
+import { SolidisFeaturedClient } from '../../../../sources/client/featured.ts';
 import {
   RespError,
   SolidisClientError,
   SolidisParserError,
-} from '../../../sources/index.ts';
+} from '../../../../sources/index.ts';
 import {
   closeClient,
   createClient,
@@ -34,14 +19,13 @@ import {
   randomBuffer,
   range,
   waitFor,
-} from '../utils/index.ts';
+} from '../../utils/index.ts';
 
-import type { FeaturedClient } from '../utils/index.ts';
+import type { FeaturedClient } from '../../utils/index.ts';
 
 describe('fragility', () => {
   const keyspace = createKeyspace('fragility');
 
-  /** Clients/servers created outside createClient() must be torn down here. */
   const mockClients: FeaturedClient[] = [];
   const mockServers: MockRedisServer[] = [];
 
@@ -74,14 +58,13 @@ describe('fragility', () => {
     let client: FeaturedClient;
 
     before(async () => {
-      client = await createClient({ commandTimeout: 800 });
+      client = await createClient({ commandTimeout: 300 });
     });
 
     after(async () => {
       await closeClient(client);
     });
 
-    /** Issued after every hostile payload to prove the pipeline is intact. */
     const assertStillHealthy = async (probe: string) => {
       const key = keyspace.key('healthy', probe);
 
@@ -90,11 +73,6 @@ describe('fragility', () => {
     };
 
     it('recovers from an empty command frame via timeout', async () => {
-      /**
-       * An empty argument vector serialises to `*0\r\n`, which the server
-       * silently ignores (no reply). The command must therefore time out, the
-       * requester must recover, and the next command must succeed.
-       */
       await assert.rejects(
         () => client.send([[]]),
         (error: Error) => /timed out/i.test(error.message),
@@ -196,7 +174,6 @@ describe('fragility', () => {
       const replies = await client.send(commands);
 
       assert.strictEqual(replies.length, commands.length);
-      /** Every command produced exactly one reply slot, in order. */
       assert.ok(replies.every((reply) => reply.length === 1));
 
       await assertStillHealthy('chaos');
@@ -225,14 +202,13 @@ describe('fragility', () => {
 
       await client.connect();
 
-      /** Garbage reply means no usable frame, so the command times out. */
       await assert.rejects(
         () => client.ping(),
         (error: Error) => /timed out/i.test(error.message),
       );
 
       await waitFor(() => parserErrors.length > 0, {
-        timeout: 1000,
+        timeout: 500,
         description: 'parser error surfaced',
       });
 
@@ -248,7 +224,6 @@ describe('fragility', () => {
         commandIndex += 1;
 
         if (commandIndex === 1) {
-          /** One extra, unsolicited reply trails the legitimate one. */
           socket.write(Buffer.from('+FIRST\r\n+UNSOLICITED\r\n', 'latin1'));
           return;
         }
@@ -265,10 +240,6 @@ describe('fragility', () => {
       const first = await client.send([['PING']]);
       const second = await client.send([['PING']]);
 
-      /**
-       * If the stray `+UNSOLICITED` had been mis-attributed, the second command
-       * would resolve to it instead of `+SECOND`.
-       */
       assert.deepStrictEqual(first, [['FIRST']]);
       assert.deepStrictEqual(second, [['SECOND']]);
     });
@@ -304,7 +275,6 @@ describe('fragility', () => {
       const server = await startMockServer();
 
       server.onData((socket) => {
-        /** Send a truncated bulk header, then drop the socket. */
         socket.write(Buffer.from('$100\r\npartial', 'latin1'));
         setTimeout(() => socket.destroy(), 10);
       });
@@ -324,7 +294,8 @@ describe('fragility', () => {
       const client = await createClient({
         autoReconnect: true,
         maxConnectionRetries: 5,
-        connectionRetryDelay: 50,
+        connectionRetryDelay: 25,
+        connectionTimeout: 500,
       });
 
       client.on('error', () => {});
@@ -337,13 +308,12 @@ describe('fragility', () => {
       const clientId = await client.clientId();
       const killer = await createClient();
 
-      /** BLPOP is guaranteed in-flight until the kill lands. */
       const blocked = client
         .blpop([blockKey], 0)
         .then(() => false)
         .catch(() => true);
 
-      await delay(50);
+      await delay(30);
       await killer.clientKill(clientId);
 
       assert.strictEqual(await blocked, true);
@@ -356,7 +326,7 @@ describe('fragility', () => {
             return false;
           }
         },
-        { timeout: 3000, interval: 50, description: 'auto-reconnect' },
+        { timeout: 2000, interval: 30, description: 'auto-reconnect' },
       );
 
       assert.strictEqual(await client.get(liveKey), 'before');
@@ -371,12 +341,13 @@ describe('fragility', () => {
       const client = await createClient({
         autoReconnect: true,
         maxConnectionRetries: 5,
-        connectionRetryDelay: 50,
+        connectionRetryDelay: 25,
+        connectionTimeout: 500,
       });
 
       client.on('error', () => {});
 
-      const total = 1500;
+      const total = 500;
       const clientId = await client.clientId();
       const killer = await createClient();
 
@@ -387,14 +358,12 @@ describe('fragility', () => {
           .catch(() => 'rejected' as const),
       );
 
-      /** Kill the connection while the batch is still draining. */
       await killer.clientKill(clientId);
 
       const settled = await Promise.all(outcomes);
       const resolved = settled.filter((value) => value === 'resolved').length;
       const rejected = settled.filter((value) => value === 'rejected').length;
 
-      /** Invariant 1: no command promise is ever silently dropped. */
       assert.strictEqual(resolved + rejected, total);
 
       await waitFor(
@@ -405,30 +374,31 @@ describe('fragility', () => {
             return false;
           }
         },
-        { timeout: 3000, interval: 50, description: 'auto-reconnect' },
+        { timeout: 2000, interval: 50, description: 'auto-reconnect' },
       );
 
       let persisted = 0;
+      const batchSize = 100;
 
-      for (const index of range(total)) {
-        if ((await client.get(keyspace.key('loss', index))) === `${index}`) {
-          persisted += 1;
+      for (let index = 0; index < total; index += batchSize) {
+        const keys = range(Math.min(batchSize, total - index)).map((j) =>
+          keyspace.key('loss', index + j),
+        );
+        const values = await client.mget(...keys);
+
+        for (let j = 0; j < values.length; j += 1) {
+          if (values[j] === `${index + j}`) {
+            persisted += 1;
+          }
         }
       }
 
-      /**
-       * Invariant 2: every write the client *acknowledged* as resolved must be
-       * durable on the server. Writes can also persist while their reply was
-       * lost to the fault (rejected-but-applied), so persisted >= resolved; the
-       * gap is exactly the work whose acknowledgement was lost in transit.
-       */
       assert.ok(
         persisted >= resolved,
         `persisted (${persisted}) must cover resolved (${resolved})`,
       );
       assert.ok(persisted <= total);
 
-      /** Invariant 3: the client is fully usable again after recovery. */
       assert.strictEqual(
         await client.set(keyspace.key('loss-final'), 'ok'),
         'OK',
@@ -454,7 +424,6 @@ describe('fragility', () => {
           /not connected|closed/i.test(error.message),
       );
 
-      /** A second attempt fails the same way; no partial revival. */
       await assert.rejects(() => client.ping());
     });
 

--- a/scripts/tests/commands/0002.keys-generic.test.ts
+++ b/scripts/tests/commands/0002.keys-generic.test.ts
@@ -1,8 +1,4 @@
-/**
- * Generic key-space commands: existence, type introspection, renaming,
- * copying, moving across databases, serialization (DUMP/RESTORE), and the full
- * expiration family (EXPIRE/PEXPIRE/EXPIREAT/??PERSIST).
- */
+/** Generic key-space commands: existence, type, rename, copy, move, DUMP/RESTORE, expiration. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0006.hashes.test.ts
+++ b/scripts/tests/commands/0006.hashes.test.ts
@@ -1,9 +1,4 @@
-/**
- * Hash value type: field CRUD, bulk get/set, counters, random sampling, and
- * incremental iteration, and the hash-field-expiration family
- * (HEXPIRE/HTTL/HPERSIST/??, which is gated on a server new enough to support
- * per-field TTLs.
- */
+/** Hash value type: field CRUD, counters, random sampling, iteration, and per-field TTLs. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0008.scan.test.ts
+++ b/scripts/tests/commands/0008.scan.test.ts
@@ -26,7 +26,7 @@ describe('scan', () => {
   it('iterates the full keyspace with a MATCH filter', async () => {
     const mapping: Record<string, string> = {};
 
-    for (let index = 0; index < 1000; index += 1) {
+    for (let index = 0; index < 200; index += 1) {
       mapping[keyspace.key('item', index)] = `${index}`;
     }
 
@@ -36,14 +36,14 @@ describe('scan', () => {
 
     for await (const batch of client.scan({
       match: `${keyspace.namespace}:item:*`,
-      count: 100,
+      count: 50,
     })) {
       for (const key of batch) {
         seen.add(key);
       }
     }
 
-    assert.strictEqual(seen.size, 1000);
+    assert.strictEqual(seen.size, 200);
   });
 
   it('filters by value type', async () => {

--- a/scripts/tests/commands/0009.transactions.test.ts
+++ b/scripts/tests/commands/0009.transactions.test.ts
@@ -1,10 +1,4 @@
-/**
- * MULTI/EXEC transactions, DISCARD, and WATCH-based optimistic locking.
- *
- * The transaction client queues commands synchronously (no await) and flushes
- * them as a single MULTI?�EXEC pipeline on exec(), returning the array of
- * per-command replies.
- */
+/** MULTI/EXEC transactions, DISCARD, and WATCH-based optimistic locking. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0010.pipeline.test.ts
+++ b/scripts/tests/commands/0010.pipeline.test.ts
@@ -1,8 +1,4 @@
-/**
- * Raw pipelining via client.send(): reply ordering, large batches that exceed
- * maxCommandsPerPipeline (forcing internal chunking), binary round-trips, and
- * error isolation within a batch.
- */
+/** Raw pipelining via client.send(): ordering, chunking, binary round-trips, error isolation. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0011.pubsub.test.ts
+++ b/scripts/tests/commands/0011.pubsub.test.ts
@@ -1,11 +1,4 @@
-/**
- * Publish/subscribe messaging: channel and pattern subscriptions, message
- * delivery, subscription bookkeeping events, shard pub/sub, and introspection
- * (PUBSUB CHANNELS / NUMSUB).
- *
- * A subscribed RESP2 connection may only issue subscription commands, so every
- * test pairs a dedicated subscriber client with a separate publisher client.
- */
+/** Publish/subscribe messaging: channels, patterns, shard pub/sub, and introspection. */
 
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it } from 'node:test';

--- a/scripts/tests/commands/0012.scripting.test.ts
+++ b/scripts/tests/commands/0012.scripting.test.ts
@@ -1,8 +1,4 @@
-/**
- * Lua scripting: EVAL/EVAL_RO, the SCRIPT LOAD + EVALSHA cache cycle, and
- * SCRIPT EXISTS. Replies flow through unchanged, so bulk strings arrive as
- * Buffers and are normalised in the assertions.
- */
+/** Lua scripting: EVAL/EVAL_RO, SCRIPT LOAD/EVALSHA, SCRIPT EXISTS. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0013.geo.test.ts
+++ b/scripts/tests/commands/0013.geo.test.ts
@@ -1,10 +1,4 @@
-/**
- * Geospatial commands: GEOADD, GEOPOS, GEODIST, GEOHASH, and GEOSEARCH with
- * radius/box queries plus the WITHCOORD/WITHDIST/WITHHASH projections.
- *
- * Uses the canonical Sicily dataset (Palermo / Catania) so distances are
- * easily cross-checked against published Redis examples.
- */
+/** Geospatial commands: GEOADD, GEOPOS, GEODIST, GEOHASH, GEOSEARCH. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0014.streams.test.ts
+++ b/scripts/tests/commands/0014.streams.test.ts
@@ -1,8 +1,4 @@
-/**
- * Stream value type: append/length/range scans, XREAD, trimming/deletion,
- * stream introspection, and the full consumer-group lifecycle
- * (XGROUP CREATE ??XREADGROUP ??XACK ??XPENDING).
- */
+/** Stream value type and consumer-group lifecycle. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
@@ -153,11 +149,6 @@ describe('streams', () => {
 
     assert.strictEqual(await client.xack(key, group, ['1-1', '2-1']), 2);
 
-    /**
-     * Verify the now-empty PEL through the range form. The summary form is
-     * avoided here because the client throws on its nil consumers field when
-     * nothing is pending.
-     */
     const remaining = await client.xpending(key, group, '-', '+', 10);
 
     assert.deepStrictEqual(remaining, []);
@@ -232,7 +223,6 @@ describe('streams', () => {
 
     const deleted = await client.xgroupDelconsumer(key, group, 'new-consumer');
 
-    /** The consumer existed but owned no pending entries, so 0 are removed. */
     assert.strictEqual(deleted, 0);
   });
 
@@ -402,11 +392,6 @@ describe('streams', () => {
 
     const pending = await client.xpending(key, group);
 
-    /**
-     * NOACK means delivered entries are never added to the PEL, so the group
-     * summary must report exactly zero pending entries. The previous
-     * conditional let a wrong shape (or a null) silently pass.
-     */
     assert.ok(
       pending !== null &&
         typeof pending === 'object' &&
@@ -528,7 +513,6 @@ describe('streams', () => {
       0,
     );
 
-    /** Both unacked entries are older than the 0ms IDLE filter. */
     assert.ok(Array.isArray(entries));
     assert.strictEqual(entries.length, 2);
     assert.deepStrictEqual(
@@ -569,7 +553,6 @@ describe('streams', () => {
       10,
     );
 
-    /** The single buffered entry must be delivered before BLOCK elapses. */
     assert.ok(Array.isArray(result));
     assert.strictEqual(result.length, 1);
     assert.deepStrictEqual(result[0].entries, [
@@ -649,7 +632,6 @@ describe('streams', () => {
       justid: true,
     });
 
-    /** JUSTID returns only the claimed ids, not the field/value payloads. */
     assert.deepStrictEqual(result, ['1-1']);
   });
 
@@ -671,7 +653,6 @@ describe('streams', () => {
       true,
     );
 
-    /** JUSTID claims the id but carries no field payload. */
     assert.strictEqual(result.nextId, '0-0');
     assert.deepStrictEqual(result.entries, [{ id: '1-1', fields: {} }]);
   });

--- a/scripts/tests/commands/0016.concurrency.test.ts
+++ b/scripts/tests/commands/0016.concurrency.test.ts
@@ -1,9 +1,4 @@
-/**
- * High-concurrency stress tests. These exercise the requester's pipelining and
- * back-pressure handling under thousands of in-flight commands, across both a
- * single shared connection and many independent clients, and verify that
- * atomic server-side operations stay consistent.
- */
+/** High-concurrency stress: pipelining, back-pressure, and atomicity. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0017.scenarios.test.ts
+++ b/scripts/tests/commands/0017.scenarios.test.ts
@@ -1,9 +1,4 @@
-/**
- * Realistic, multi-command application scenarios that combine several data
- * types and mix synchronous transaction semantics with asynchronous fan-out:
- * rate limiting, leaderboards, work queues, session storage, cache-aside, and
- * tag indexes.
- */
+/** Realistic multi-command application scenarios. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0018.binary-resp3.test.ts
+++ b/scripts/tests/commands/0018.binary-resp3.test.ts
@@ -1,9 +1,4 @@
-/**
- * Binary safety and RESP3 protocol coverage: arbitrary byte payloads, embedded
- * NUL bytes, multi-byte UTF-8, large values, and verification that the core
- * commands behave identically once the connection negotiates RESP3 (where
- * maps, sets, and doubles use dedicated wire types).
- */
+/** Binary safety and RESP3 protocol coverage. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';

--- a/scripts/tests/commands/0019.parser.test.ts
+++ b/scripts/tests/commands/0019.parser.test.ts
@@ -1,13 +1,4 @@
-/**
- * Aggressive, protocol-level fuzzing of the RESP parser.
- *
- * These tests drive {@link SolidisParser} directly with hand-crafted byte
- * sequences ??every RESP2 and RESP3 type, binary payloads containing the CRLF
- * delimiter, fragmentation down to a single byte per chunk, deeply nested
- * aggregates, and deliberately malformed frames ??to confirm the parser is
- * binary-safe, reassembles partial frames correctly, and fails loudly (with a
- * SolidisParserError) on corrupt input rather than crashing or hanging.
- */
+/** Protocol-level fuzzing of the RESP parser. */
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';

--- a/scripts/tests/commands/0026.consistency.test.ts
+++ b/scripts/tests/commands/0026.consistency.test.ts
@@ -1,14 +1,4 @@
-/**
- * Reply-correlation consistency.
- *
- * The requester resolves replies *positionally* from an in-flight queue, so a
- * single miscounted or misrouted reply would silently shift every subsequent
- * answer onto the wrong promise. These tests hammer the client with large,
- * randomly interleaved bursts of heterogeneous commands where **each operation
- * carries its own uniquely-determined expected answer**, then assert every
- * resolved value matches the command that produced it. Any desynchronisation
- * surfaces as a concrete value mismatch rather than a vague failure.
- */
+/** Reply-correlation consistency. */
 
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
@@ -25,16 +15,11 @@ import {
 
 import type { FeaturedClient } from '../utils/index.ts';
 
-/** A single self-verifying operation: it runs a command and checks its reply. */
 interface ConsistencyOperation {
   label: string;
   execute: () => Promise<void>;
 }
 
-/**
- * Deterministic pseudo-random generator so a failing seed is reproducible and
- * the interleaving is identical across runs.
- */
 function createRandom(seed: number): () => number {
   let state = seed >>> 0;
 
@@ -69,11 +54,6 @@ describe('consistency', () => {
     await closeAllClients();
   });
 
-  /**
-   * Builds one operation drawn from a varied pool. Every generator seeds its
-   * own unique key/value so the expected reply is known up-front and unique
-   * enough to detect cross-talk between concurrent commands.
-   */
   function buildOperation(
     target: FeaturedClient,
     index: number,
@@ -83,7 +63,6 @@ describe('consistency', () => {
 
     switch (variant) {
       case 0: {
-        /** ECHO is the sharpest probe: the reply must equal the unique input. */
         const token = `echo-${tag}`;
 
         return {
@@ -211,10 +190,6 @@ describe('consistency', () => {
       }
 
       case 10: {
-        /**
-         * A deliberately failing command interleaved with the rest: the inline
-         * RespError must land on *this* operation, not corrupt its neighbours.
-         */
         const key = keyspace.key('type-error', tag);
 
         return {
@@ -231,7 +206,6 @@ describe('consistency', () => {
       }
 
       default: {
-        /** A multi-command pipeline whose replies must stay internally ordered. */
         const key = keyspace.key('pipeline', tag);
 
         return {
@@ -300,7 +274,6 @@ describe('consistency', () => {
       tokens.map((token) => client.echo(token)),
     );
 
-    /** A single shifted reply would break this exact, ordered comparison. */
     assert.deepStrictEqual(replies, tokens);
   });
 
@@ -319,11 +292,6 @@ describe('consistency', () => {
   });
 
   it('interleaves blocking and non-blocking commands without cross-talk', async () => {
-    /**
-     * A blocking BLPOP occupies its own connection until a push arrives. Fast
-     * commands on a *separate* connection must stay perfectly correlated in the
-     * meantime, and the delayed BLPOP reply must route back to its own promise.
-     */
     const blockKey = keyspace.key('blpop-target');
     const blockingClient = await createClient();
     const pusher = await createClient();
@@ -331,7 +299,6 @@ describe('consistency', () => {
     try {
       const blocked = blockingClient.blpop([blockKey], 2);
 
-      /** These run on the unblocked main connection and must resolve at once. */
       const fast = await Promise.all(
         range(50).map((index) => client.echo(`fast-${index}`)),
       );

--- a/scripts/tests/commands/0027.stress-correlation.test.ts
+++ b/scripts/tests/commands/0027.stress-correlation.test.ts
@@ -1,18 +1,4 @@
-/**
- * Reply-correlation STRESS — adversarial "try to break it" edition.
- *
- * Where 0026 verifies correlation under normal options, this suite deliberately
- * cripples the requester with degenerate limits (one command per pipeline, one
- * reply per processing chunk, byte-at-a-time socket writes, a tiny parser
- * buffer that must grow/shift constantly) and then floods it with tens of
- * thousands of commands whose answers are individually unique. Every reply is
- * checked against the command that produced it; the suite reports the observed
- * desync/loss rate and asserts it is exactly zero.
- *
- * If any configuration produces a single mismatch, the printed summary makes
- * the loss rate explicit so a regression can be quantified rather than merely
- * detected.
- */
+/** Reply-correlation stress with degenerate requester limits. */
 
 import assert from 'node:assert/strict';
 import { randomBytes, randomUUID } from 'node:crypto';
@@ -39,9 +25,7 @@ describe('stress-correlation', () => {
   const keyspace = createKeyspace('stress-correlation');
   const tracked: FeaturedClient[] = [];
 
-  before(() => {
-    /** nothing global; each test owns its degenerate client */
-  });
+  before(() => {});
 
   after(async () => {
     await Promise.all(tracked.map((client) => closeClient(client)));
@@ -57,10 +41,6 @@ describe('stress-correlation', () => {
     return client;
   };
 
-  /**
-   * Runs `count` self-verifying operations concurrently and tallies how many
-   * replies failed to match the command that issued them.
-   */
   async function burst(
     client: FeaturedClient,
     count: number,
@@ -93,7 +73,6 @@ describe('stress-correlation', () => {
           }
 
           case 1: {
-            /** Binary ECHO stresses the parser buffer with raw bytes. */
             const payload = randomBytes(48 + (index % 80));
             const reply = await client.echo(payload.toString('latin1'));
 
@@ -145,7 +124,6 @@ describe('stress-correlation', () => {
           }
 
           default: {
-            /** A multi-reply pipeline whose internal order must be preserved. */
             const key = keyspace.key('pipe', tag);
             const replies = await client.send([
               ['SET', key, tag],
@@ -213,13 +191,13 @@ describe('stress-correlation', () => {
   it('stays correlated with one command per pipeline chunk', async () => {
     const client = await make({ maxCommandsPerPipeline: 1 });
 
-    assertClean('maxCommandsPerPipeline=1', await burst(client, 8000));
+    assertClean('maxCommandsPerPipeline=1', await burst(client, 3000));
   });
 
   it('stays correlated with one reply per processing chunk', async () => {
     const client = await make({ maxProcessRepliesPerChunk: 1 });
 
-    assertClean('maxProcessRepliesPerChunk=1', await burst(client, 8000));
+    assertClean('maxProcessRepliesPerChunk=1', await burst(client, 3000));
   });
 
   it('stays correlated with byte-at-a-time socket writes', async () => {
@@ -229,7 +207,7 @@ describe('stress-correlation', () => {
       socketWriteTimeout: 120000,
     });
 
-    assertClean('maxSocketWriteSizePerOnce=1', await burst(client, 2000));
+    assertClean('maxSocketWriteSizePerOnce=1', await burst(client, 500));
   });
 
   it('stays correlated with a tiny, constantly-resized parser buffer', async () => {
@@ -237,7 +215,7 @@ describe('stress-correlation', () => {
       parser: { buffer: { initial: 64, shiftThreshold: 16 } },
     });
 
-    assertClean('tiny-parser-buffer', await burst(client, 8000));
+    assertClean('tiny-parser-buffer', await burst(client, 3000));
   });
 
   it('stays correlated with every limit cranked to its worst case at once', async () => {
@@ -250,12 +228,12 @@ describe('stress-correlation', () => {
       parser: { buffer: { initial: 32, shiftThreshold: 8 } },
     });
 
-    assertClean('all-degenerate', await burst(client, 2000));
+    assertClean('all-degenerate', await burst(client, 500));
   });
 
   it('stays correlated across 24 degenerate clients pounding in parallel', async () => {
     const clients = await Promise.all(
-      range(24).map((index) =>
+      range(12).map((index) =>
         make({
           maxCommandsPerPipeline: 1 + (index % 3),
           maxProcessRepliesPerChunk: 1 + (index % 4),
@@ -264,7 +242,7 @@ describe('stress-correlation', () => {
     );
 
     const results = await Promise.all(
-      clients.map((client) => burst(client, 600)),
+      clients.map((client) => burst(client, 300)),
     );
 
     const aggregate = results.reduce<BurstResult>(
@@ -276,6 +254,6 @@ describe('stress-correlation', () => {
       { total: 0, mismatches: 0, errors: 0 },
     );
 
-    assertClean('24-way-degenerate', aggregate);
+    assertClean('12-way-degenerate', aggregate);
   });
 });

--- a/scripts/tests/commands/0028.parser-edge.test.ts
+++ b/scripts/tests/commands/0028.parser-edge.test.ts
@@ -1,12 +1,4 @@
-/**
- * Parser edge & adversarial branch coverage.
- *
- * Complements 0019 by driving the rarely-hit corners of {@link SolidisParser}:
- * negative-length aggregates, frames truncated at every internal boundary,
- * null map keys, attribute frames whose payload is not a map, and malformed
- * RESP3 scalars (doubles, big numbers, blob errors) that must degrade into a
- * RespError rather than throwing or corrupting the stream.
- */
+/** Parser edge & adversarial branch coverage. */
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';

--- a/scripts/tests/commands/0029.resp3-shapes.test.ts
+++ b/scripts/tests/commands/0029.resp3-shapes.test.ts
@@ -1,16 +1,4 @@
-/**
- * RESP3 reply-shape coverage.
- *
- * The default test connection speaks RESP2. RESP3 changes the wire shape of
- * many replies — doubles arrive as native numbers, maps as `Map`, sets as
- * `Set`, and sorted-set members as nested `[member, score]` pairs. This suite
- * reconnects with `protocol: 'RESP3'` and asserts the client normalises every
- * one of those shapes to exactly the value a RESP2 caller would receive.
- *
- * These cases previously surfaced real parser bugs (ZPOPMIN/ZPOPMAX with COUNT,
- * ZMSCORE, GEOPOS, XINFO GROUPS, TS.INFO all threw on RESP3 shapes); the parsers
- * were fixed at the source and these assertions now guard against regressions.
- */
+/** RESP3 reply-shape coverage and regression guards. */
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
@@ -401,7 +389,6 @@ describe('resp3-shapes', () => {
     const [entry] = results;
 
     assert.strictEqual(entry.member, 'Palermo');
-    /** RESP3 returns the distance as a native double, not a bulk string. */
     assert.strictEqual(typeof entry.distance, 'number');
     assert.ok(entry.distance !== undefined && entry.distance > 0);
     assert.ok(entry.position !== undefined);

--- a/scripts/tests/coverage.ts
+++ b/scripts/tests/coverage.ts
@@ -1,15 +1,9 @@
 /**
  * Unified coverage runner.
  *
- * The two test tiers cannot share a single process: command suites are
- * timing-sensitive and must run in isolated child processes (in parallel),
- * while client suites mutate global server state and must run serially. To
- * still produce one merged coverage report, both tiers write raw V8 coverage
- * into a shared directory via NODE_V8_COVERAGE, which c8 then merges.
- *
- * Child processes use native TypeScript stripping rather than the esbuild
- * loader so each source module keeps its own file identity (the loader bundles
- * everything inline, which hides sources/ from V8 coverage).
+ * commands: parallel. client/admin: serial, alone (global state).
+ * client/{core,resilience,fault}: serial per group, groups in parallel.
+ * Uses NODE_V8_COVERAGE + native TS stripping for per-file identity.
  */
 
 import { spawn } from 'node:child_process';
@@ -35,6 +29,10 @@ function listTests(group: string): string[] {
 }
 
 function spawnTests(files: string[], concurrency?: number): Promise<number> {
+  if (files.length === 0) {
+    return Promise.resolve(0);
+  }
+
   const command = [
     '--experimental-strip-types',
     '--no-warnings',
@@ -76,10 +74,18 @@ function report(): Promise<number> {
 }
 
 const commandsCode = await spawnTests(listTests('commands'));
-const clientCode = await spawnTests(listTests('client'), 1);
+const adminCode = await spawnTests(listTests('client/admin'), 1);
+const restCodes = await Promise.all(
+  ['client/core', 'client/resilience', 'client/fault'].map((group) =>
+    spawnTests(listTests(group), 1),
+  ),
+);
 
 await report();
 
 rmSync(coverageDirectory, { recursive: true });
 
-process.exitCode = commandsCode === 0 && clientCode === 0 ? 0 : 1;
+const allClientCodes = [adminCode, ...restCodes];
+
+process.exitCode =
+  commandsCode === 0 && allClientCodes.every((code) => code === 0) ? 0 : 1;

--- a/scripts/tests/utils/teardown.ts
+++ b/scripts/tests/utils/teardown.ts
@@ -1,18 +1,4 @@
-/**
- * Root-level safety net that force-closes every client created during a test
- * file once all of its tests have settled.
- *
- * `node:test` runs `beforeEach`/`before` hooks for a test that later calls
- * `context.skip()` inside its body, but it does NOT run the matching
- * `afterEach`/`after` hooks for that skipped test. Any client opened in a
- * setup hook for a capability-gated test therefore leaks its TCP socket, which
- * keeps the event loop alive and hangs the runner indefinitely (the process
- * never exits because a handle is still open).
- *
- * Registering a single root `after` hook here — imported transitively by every
- * suite through `./index.ts` — guarantees that all tracked clients are closed
- * regardless of how individual tests skip or fail.
- */
+/** Root-level after hook: force-closes all tracked clients after each suite. */
 
 import { after } from 'node:test';
 

--- a/scripts/workflows/coverage/comment.ts
+++ b/scripts/workflows/coverage/comment.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+
+const MARKER = '<!-- solidis-coverage -->';
+
+const [reportPath, repository, pullRequestNumber, token] =
+  process.argv.slice(2);
+
+if (!reportPath || !repository || !pullRequestNumber || !token) {
+  console.error(
+    'Usage: comment.ts <report-path> <owner/repo> <pull-request-number> <github-token>',
+  );
+  process.exit(1);
+}
+
+const reportContent = readFileSync(reportPath, 'utf8');
+const commentBody = `${MARKER}\n${reportContent}`;
+
+const [owner, repositoryName] = repository.split('/');
+const issueNumber = Number(pullRequestNumber);
+
+const requestHeaders = {
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+};
+
+const apiBase = `https://api.github.com/repos/${owner}/${repositoryName}`;
+
+const commentsResponse = await fetch(
+  `${apiBase}/issues/${issueNumber}/comments?per_page=100`,
+  { headers: requestHeaders },
+);
+
+if (!commentsResponse.ok) {
+  console.error(`Failed to list comments: ${commentsResponse.status}`);
+  process.exit(1);
+}
+
+const comments = (await commentsResponse.json()) as {
+  id: number;
+  body?: string;
+}[];
+
+const existingComment = comments.find((comment) =>
+  comment.body?.includes(MARKER),
+);
+
+if (existingComment) {
+  const response = await fetch(
+    `${apiBase}/issues/comments/${existingComment.id}`,
+    {
+      method: 'PATCH',
+      headers: { ...requestHeaders, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: commentBody }),
+    },
+  );
+
+  if (!response.ok) {
+    console.error(`Failed to update comment: ${response.status}`);
+    process.exit(1);
+  }
+
+  console.log(`Updated comment #${existingComment.id}`);
+} else {
+  const response = await fetch(`${apiBase}/issues/${issueNumber}/comments`, {
+    method: 'POST',
+    headers: { ...requestHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body: commentBody }),
+  });
+
+  if (!response.ok) {
+    console.error(`Failed to create comment: ${response.status}`);
+    process.exit(1);
+  }
+
+  console.log('Created coverage comment');
+}

--- a/scripts/workflows/coverage/report.ts
+++ b/scripts/workflows/coverage/report.ts
@@ -129,7 +129,9 @@ function progressBar(percentage: number): string {
 }
 
 function formatPercentage(percentage: number): string {
-  return percentage === 100 ? '100%' : `**${percentage}%**`;
+  return percentage === 100
+    ? '🟢 **100%**'
+    : `${statusIcon(percentage)} ${percentage}%`;
 }
 
 function buildMarkdown(

--- a/scripts/workflows/coverage/report.ts
+++ b/scripts/workflows/coverage/report.ts
@@ -1,0 +1,209 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+interface SummaryCategory {
+  name: string;
+  percentage: number;
+  covered: number;
+  total: number;
+}
+
+interface FileEntry {
+  name: string;
+  statements: number;
+  branches: number;
+  functions: number;
+  lines: number;
+  uncovered: string;
+}
+
+interface DirectoryGroup {
+  name: string;
+  statements: number;
+  branches: number;
+  functions: number;
+  lines: number;
+  files: FileEntry[];
+}
+
+const ROW_PATTERN =
+  /^(\s*)(\S.*?)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*(.*?)\s*$/;
+
+function parseSummary(raw: string): SummaryCategory[] {
+  const lines = raw.split('\n');
+  const startIndex = lines.findIndex((line) =>
+    line.includes('======== Coverage summary ========'),
+  );
+
+  if (startIndex === -1) {
+    return [];
+  }
+
+  const categories: SummaryCategory[] = [];
+
+  for (const line of lines.slice(startIndex)) {
+    const match = line.match(/^(\w+)\s*:\s*([\d.]+)%\s*\(\s*(\d+)\/(\d+)\s*\)/);
+
+    if (match) {
+      categories.push({
+        name: match[1],
+        percentage: Number(match[2]),
+        covered: Number(match[3]),
+        total: Number(match[4]),
+      });
+    }
+  }
+
+  return categories;
+}
+
+function parseDetailedTable(raw: string): DirectoryGroup[] {
+  const lines = raw.split('\n');
+  const groups: DirectoryGroup[] = [];
+  let currentGroup: DirectoryGroup | null = null;
+
+  for (const line of lines) {
+    const match = line.match(ROW_PATTERN);
+
+    if (!match) {
+      continue;
+    }
+
+    const [
+      ,
+      indent,
+      name,
+      statements,
+      branches,
+      functions,
+      linesValue,
+      uncovered,
+    ] = match;
+    const depth = indent.length;
+
+    if (name === 'All files' || name === 'File') {
+      continue;
+    }
+
+    if (depth <= 1) {
+      currentGroup = {
+        name: name.trim(),
+        statements: Number(statements),
+        branches: Number(branches),
+        functions: Number(functions),
+        lines: Number(linesValue),
+        files: [],
+      };
+      groups.push(currentGroup);
+    } else if (currentGroup) {
+      currentGroup.files.push({
+        name: name.trim(),
+        statements: Number(statements),
+        branches: Number(branches),
+        functions: Number(functions),
+        lines: Number(linesValue),
+        uncovered: uncovered.trim(),
+      });
+    }
+  }
+
+  return groups;
+}
+
+function statusIcon(percentage: number): string {
+  if (percentage >= 90) {
+    return '🟢';
+  }
+
+  if (percentage >= 70) {
+    return '🟡';
+  }
+
+  return '🔴';
+}
+
+function progressBar(percentage: number): string {
+  const filled = Math.round(percentage / 5);
+  const empty = 20 - filled;
+
+  return `${'█'.repeat(filled)}${'░'.repeat(empty)}`;
+}
+
+function formatPercentage(percentage: number): string {
+  return percentage === 100 ? '100%' : `**${percentage}%**`;
+}
+
+function buildMarkdown(
+  summary: SummaryCategory[],
+  groups: DirectoryGroup[],
+): string {
+  const linesCategory = summary.find((category) => category.name === 'Lines');
+  const overallPercentage = linesCategory?.percentage ?? 0;
+
+  const sections: string[] = [
+    `## ${statusIcon(overallPercentage)} Coverage Report`,
+    '',
+    `> **Overall: ${overallPercentage}%** \`${progressBar(overallPercentage)}\``,
+    '',
+    '| | Category | Coverage | Covered / Total |',
+    '|---|----------|----------|-----------------|',
+    ...summary.map(
+      (category) =>
+        `| ${statusIcon(category.percentage)} | ${category.name} | **${category.percentage}%** | ${category.covered} / ${category.total} |`,
+    ),
+  ];
+
+  if (groups.length === 0) {
+    return sections.join('\n');
+  }
+
+  sections.push('', '---', '');
+
+  for (const group of groups) {
+    const incompleteFiles = group.files.filter((file) => file.lines < 100);
+    const icon = statusIcon(group.lines);
+    const label =
+      incompleteFiles.length === 0
+        ? `${icon} ${group.name} — ${group.lines}% (all files 100%)`
+        : `${icon} ${group.name} — ${group.lines}% (${incompleteFiles.length} file${incompleteFiles.length > 1 ? 's' : ''} below 100%)`;
+
+    const rows = group.files.map(
+      (file) =>
+        `| ${file.name} | ${formatPercentage(file.statements)} | ${formatPercentage(file.branches)} | ${formatPercentage(file.functions)} | ${formatPercentage(file.lines)} | ${file.uncovered ? `\`${file.uncovered}\`` : ''} |`,
+    );
+
+    sections.push(
+      `<details><summary>${label}</summary>`,
+      '',
+      '| File | Statements | Branch | Funcs | Lines | Uncovered |',
+      '|------|------------|--------|-------|-------|-----------|',
+      ...rows,
+      '',
+      '</details>',
+      '',
+    );
+  }
+
+  return sections.join('\n');
+}
+
+const [inputPath, outputPath] = process.argv.slice(2);
+
+if (!inputPath || !outputPath) {
+  console.error('Usage: report.ts <coverage-output-file> <output-file>');
+  process.exit(1);
+}
+
+const raw = readFileSync(inputPath, 'utf8');
+const summary = parseSummary(raw);
+
+if (summary.length === 0) {
+  console.error('Could not parse coverage summary from output.');
+  process.exit(1);
+}
+
+const groups = parseDetailedTable(raw);
+const markdown = buildMarkdown(summary, groups);
+
+writeFileSync(outputPath, markdown);
+
+console.log(`Report written to ${outputPath}`);

--- a/sources/modules/requester.ts
+++ b/sources/modules/requester.ts
@@ -33,8 +33,6 @@ import type {
 export class SolidisRequester {
   #options: SolidisRequesterOptions;
 
-  #sessionId = 0;
-
   #parser: SolidisParser;
 
   #requestQueue: SolidisPipelineRequest[] = [];
@@ -121,7 +119,6 @@ export class SolidisRequester {
       );
 
       const pipelineRequest: SolidisPipelineRequest = {
-        sessionId: this.#sessionId,
         resolve: () => {},
         reject: (error: unknown) => {
           this.#rejectSubRequests(pipelineRequest, error);
@@ -145,8 +142,6 @@ export class SolidisRequester {
   }
 
   async #flushRequestQueue() {
-    const sessionId = this.#sessionId;
-
     this.#debug?.('debug', 'Solidis requester will flush queue.');
 
     while (this.#requestQueue.length > 0) {
@@ -154,14 +149,6 @@ export class SolidisRequester {
 
       if (!request) {
         return;
-      }
-
-      if (request.sessionId !== sessionId) {
-        request.reject(
-          new SolidisRequesterError('Stale request: old session.'),
-        );
-
-        continue;
       }
 
       this.#inflightQueue.push(request);
@@ -172,10 +159,7 @@ export class SolidisRequester {
       );
 
       try {
-        await this.#writeBufferToSocketInChunks(
-          request.commandsBuffer,
-          sessionId,
-        );
+        await this.#writeBufferToSocketInChunks(request.commandsBuffer);
       } catch (error: unknown) {
         this.recoveryFromFault(wrapWithSolidisRequesterError(error));
         break;
@@ -186,10 +170,6 @@ export class SolidisRequester {
   #setRequestTimeout(request: SolidisPipelineRequest, action: 'set' | 'clear') {
     if (action === 'set' && this.#options.commandTimeout > 0) {
       request.timeoutId = setTimeout(() => {
-        if (request.sessionId !== this.#sessionId) {
-          return;
-        }
-
         this.recoveryFromFault(
           new SolidisRequesterError(
             `Solidis command(s) timed out after ${this.#options.commandTimeout} ms.`,
@@ -203,7 +183,7 @@ export class SolidisRequester {
     }
   }
 
-  async #writeBufferToSocketInChunks(buffer: Buffer, sessionId: number) {
+  async #writeBufferToSocketInChunks(buffer: Buffer) {
     const { maxSocketWriteSizePerOnce } = this.#options;
 
     const eventHandlers = this.#getSocketWriteEventHandlers();
@@ -223,7 +203,7 @@ export class SolidisRequester {
           await eventHandlers.waitForDrain();
         }
 
-        if (this.#isOnRecovery || sessionId !== this.#sessionId) {
+        if (this.#isOnRecovery) {
           throw new SolidisRequesterError('Stale request: old session.');
         }
 
@@ -581,10 +561,6 @@ export class SolidisRequester {
     const request = this.#inflightQueue[0];
     const reply = parsedReplies.shift();
 
-    if (request.sessionId !== this.#sessionId) {
-      return;
-    }
-
     if (typeof reply !== 'undefined') {
       request.parsedReplies.push(reply);
     }
@@ -600,10 +576,6 @@ export class SolidisRequester {
 
   #resolvePipelineRequest(request: SolidisPipelineRequest) {
     this.#setRequestTimeout(request, 'clear');
-
-    if (request.sessionId !== this.#sessionId) {
-      return;
-    }
 
     this.#pendingSubscribeCommandCount = Math.max(
       0,

--- a/sources/types/solidis.ts
+++ b/sources/types/solidis.ts
@@ -143,7 +143,6 @@ export interface SolidisPipelineSubRequest {
 }
 
 export interface SolidisPipelineRequest {
-  sessionId: number;
   resolve: SolidisRequestResolveHandler;
   reject: SolidisRejectHandler;
   commandsBuffer: Buffer;


### PR DESCRIPTION
## Summary
- Remove dead `sessionId` field from `SolidisRequester` — initialized to `0` but never modified, making all session-based stale checks always evaluate to `false`
- Add coverage report pipeline to CI: parse c8 output into a formatted markdown report, post it to GitHub Job Summary, and leave a sticky PR comment with per-directory breakdown
- Extract CI logic into standalone scripts (`scripts/workflows/coverage/report.ts`, `comment.ts`) to keep the workflow YAML declarative
## Changes
**Dead code removal (`sources/modules/requester.ts`, `sources/types/solidis.ts`)**
- Remove `#sessionId` private field and `SolidisPipelineRequest.sessionId` type member
- Remove 5 stale-session guard branches that were always unreachable
- Retain `#isOnRecovery` check in `#writeBufferToSocketInChunks` which already handles the recovery case
**Coverage reporting (`scripts/workflows/coverage/`, `.github/workflows/coverage.yaml`)**
- `report.ts` — parses c8 `text-summary` and `text` output, generates markdown with overall progress bar, per-category table, and collapsible per-directory file details (only files below 100% shown)
- `comment.ts` — posts or updates a sticky PR comment via GitHub REST API using an HTML marker for idempotency
- Workflow captures stdout via `tee`, pipes through the report script, writes to `$GITHUB_STEP_SUMMARY`, and conditionally posts a PR comment
