### PR TITLE
feat: Implements locale-specific benchmark markdown

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -97,7 +97,7 @@ jobs:
           path: snapshots
 
       - name: Merge snapshots
-        run: npm run benchmark:merge -- snapshots/**/*.benchmark -o benchmark-report.md
+        run: npm run benchmark:merge -- snapshots/**/*.benchmark -o benchmark-report.md -s merged.benchmark
 
       - name: Check if PR should be created
         id: check
@@ -112,7 +112,7 @@ jobs:
 
       - name: Update README files
         if: steps.check.outputs.pr == 'true'
-        run: npm run benchmark:replace:readme -- benchmark-report.md
+        run: npm run benchmark:replace:readme -- merged.benchmark
 
       - name: Create pull request
         if: steps.check.outputs.pr == 'true'
@@ -128,5 +128,5 @@ jobs:
 
             - Ran **19** benchmark cases independently
             - Merged all results into a single report
-            - Updated the benchmark section in `README.md`
+            - Updated the benchmark section in all `README*.md` files (localized)
           labels: benchmark,automated

--- a/scripts/benchmarks/shared/markdown/index.ts
+++ b/scripts/benchmarks/shared/markdown/index.ts
@@ -2,8 +2,10 @@ import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import { formatLargeNumber, formatPayloadSize } from '../utils.ts';
+import { en } from './locales/index.ts';
 
 import type { BenchConfig, ComparedResult, LibraryName } from '../types.ts';
+import type { BenchmarkLocale } from './locales/types.ts';
 
 interface ResultGroup {
   operation: string;
@@ -134,34 +136,15 @@ function makeProgressBar(ratio: number | null, maximumRatio: number): string {
   return '█'.repeat(filled) + '░'.repeat(10 - filled);
 }
 
-const OPERATION_DISPLAY_NAMES: Record<string, string> = {
-  set: 'Set',
-  getBuffer: 'Get Buffer',
-  'hash:HSET+HGET+HGETALL': 'Hash Round-Trip',
-  'hash:HMSET+HMGET+HDEL': 'Hash Mutation',
-  'set:SADD+SISMEMBER+SMEMBERS': 'Set Read',
-  'set:SADD+SISMEMBER+SREM': 'Set Mutation',
-  'expire:SET+EXPIRE+TTL': 'Expire',
-  'nonTx:SETPX+GET': 'Non-Transaction',
-  'list:LPUSH+RPUSH+LRANGE': 'List Range',
-  'list:LPUSH+RPUSH+LPOP+RPOP+LLEN': 'List Mutation',
-  'counter:INCR+DECR': 'Counter',
-  'transaction:SET+EXPIRE+GET': 'Transaction',
-  'transactionMixed:SET+GET': 'Transaction Mixed',
-  'multiKey:MSET+MGET': 'Multi-Key',
-  'pipeline:SET+INCR+GET': 'Pipeline Mixed',
-  'stream:XADD+XRANGE+XLEN': 'Stream',
-  'zset:ZADD+ZRANGE+ZREM': 'Sorted Set',
-  'info:INFO+CONFIGGET': 'Info / Config',
-  'pubsub:PUBLISH+MESSAGE': 'Pub/Sub',
-};
-
-function formatOperationName(raw: string): {
+function formatOperationName(
+  raw: string,
+  displayNames: Record<string, string>,
+): {
   display: string;
   commands: string;
 } {
   const colonIndex = raw.indexOf(':');
-  const display = OPERATION_DISPLAY_NAMES[raw] ?? raw;
+  const display = displayNames[raw] ?? raw;
 
   if (colonIndex === -1) {
     return { display, commands: raw.toUpperCase() };
@@ -187,26 +170,37 @@ function formatDateTime(): string {
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }
 
-function buildConfigurationTable(configuration: BenchConfig): string {
+function buildConfigurationTable(
+  configuration: BenchConfig,
+  locale: BenchmarkLocale,
+): string {
+  const labels = locale.configLabels;
+
   const rows = [
-    ['Mode', `\`${configuration.mode}\``],
-    ['Payload Sizes', configuration.sizes.map(formatPayloadSize).join(', ')],
-    ['Iterations', configuration.iterations.toLocaleString()],
-    ['Warmup', configuration.warmup.toLocaleString()],
-    ['Clients', `${configuration.clients}`],
-    ['Concurrency / Client', `${configuration.concurrency}`],
+    [labels.mode, `\`${configuration.mode}\``],
     [
-      'Total Concurrency',
+      labels.payloadSizes,
+      configuration.sizes.map(formatPayloadSize).join(', '),
+    ],
+    [labels.iterations, configuration.iterations.toLocaleString()],
+    [labels.warmup, configuration.warmup.toLocaleString()],
+    [labels.clients, `${configuration.clients}`],
+    [labels.concurrencyPerClient, `${configuration.concurrency}`],
+    [
+      labels.totalConcurrency,
       `${configuration.clients * configuration.concurrency}`,
     ],
-    ['Repeats', `${configuration.repeats}`],
-    ['Cooldown', `${configuration.cooldownMs}ms`],
-    ['Platform', `${process.platform} ${process.arch}`],
-    ['Node.js', process.version],
-    ['Date', formatDateTime()],
+    [labels.repeats, `${configuration.repeats}`],
+    [labels.cooldown, `${configuration.cooldownMs}ms`],
+    [labels.platform, `${process.platform} ${process.arch}`],
+    [labels.nodeJs, process.version],
+    [labels.date, formatDateTime()],
   ];
 
-  const lines: string[] = ['| Parameter | Value |', '|:----------|:------|'];
+  const lines: string[] = [
+    `| ${labels.parameter} | ${labels.value} |`,
+    '|:----------|:------|',
+  ];
 
   for (const [key, value] of rows) {
     lines.push(`| ${key} | ${value} |`);
@@ -291,15 +285,18 @@ function buildMainTable(
   baselineLibrary: LibraryName,
   solidisLibrary: LibraryName,
   maximumRatio: number,
+  locale: BenchmarkLocale,
 ): TableBuildResult {
   const comparableGroups = groups.filter((group) => group.comparable);
 
   if (comparableGroups.length === 0) {
-    return { table: '*No comparable results.*', lastRank: 0 };
+    return { table: locale.noComparableResults, lastRank: 0 };
   }
 
+  const h = locale.mainTableHeaders;
+
   const header = [
-    `| | Benchmark | Commands | ${solidisLibrary} | ${baselineLibrary} | Difference | Performance |`,
+    `| | ${h.benchmark} | ${h.commands} | ${solidisLibrary} | ${baselineLibrary} | ${h.difference} | ${h.performance} |`,
     '|---:|:---|:---:|:---:|:---:|:---:|:---|',
   ];
 
@@ -316,7 +313,10 @@ function buildMainTable(
       continue;
     }
 
-    const { display, commands } = formatOperationName(group.operation);
+    const { display, commands } = formatOperationName(
+      group.operation,
+      locale.operationDisplayNames,
+    );
 
     const solidisElapsed = formatElapsedMilliseconds(
       solidisResult.elapsedMs,
@@ -353,6 +353,7 @@ function buildNonComparableTable(
   solidisLibrary: LibraryName,
   startRank: number,
   maximumRatio: number,
+  locale: BenchmarkLocale,
 ): string {
   const nonComparableGroups = groups.filter((group) => !group.comparable);
 
@@ -360,8 +361,10 @@ function buildNonComparableTable(
     return '';
   }
 
+  const h = locale.mainTableHeaders;
+
   const header = [
-    `| | Benchmark | Commands | ${solidisLibrary} | ${baselineLibrary} | Difference | Performance |`,
+    `| | ${h.benchmark} | ${h.commands} | ${solidisLibrary} | ${baselineLibrary} | ${h.difference} | ${h.performance} |`,
     '|---:|:---|:---:|:---:|:---:|:---:|:---|',
   ];
 
@@ -378,7 +381,10 @@ function buildNonComparableTable(
       continue;
     }
 
-    const { display, commands } = formatOperationName(group.operation);
+    const { display, commands } = formatOperationName(
+      group.operation,
+      locale.operationDisplayNames,
+    );
 
     const solidisElapsed = formatElapsedMilliseconds(
       solidisResult.elapsedMs,
@@ -412,6 +418,7 @@ function buildNonComparableTable(
 function buildDetailedMetricsTable(
   groups: ResultGroup[],
   solidisLibrary: LibraryName,
+  locale: BenchmarkLocale,
 ): string {
   const comparableGroups = groups.filter((group) => group.comparable);
 
@@ -419,8 +426,10 @@ function buildDetailedMetricsTable(
     return '';
   }
 
+  const h = locale.detailedMetricsHeaders;
+
   const header = [
-    '| Benchmark | Library | ops/s | cmds/s | Elapsed | Spread |',
+    `| ${h.benchmark} | ${h.library} | ${h.opsPerSec} | ${h.cmdsPerSec} | ${h.elapsed} | ${h.spread} |`,
     '|:---|:---|---:|---:|---:|---:|',
   ];
 
@@ -437,7 +446,10 @@ function buildDetailedMetricsTable(
       return 0;
     });
 
-    const { display, commands } = formatOperationName(group.operation);
+    const { display, commands } = formatOperationName(
+      group.operation,
+      locale.operationDisplayNames,
+    );
     const label = commands ? `${display}: ${commands}` : display;
     let isFirstInGroup = true;
 
@@ -480,6 +492,7 @@ export function generateMarkdownReport(
   results: ComparedResult[],
   baselineLibrary: LibraryName,
   configuration: BenchConfig,
+  locale: BenchmarkLocale = en,
 ): string {
   const solidisLibrary = findSolidisLibrary(results);
   const sortedGroups = buildSortedResultGroups(results);
@@ -493,13 +506,11 @@ export function generateMarkdownReport(
   const summary = buildSummaryStats(results, solidisLibrary);
   const totalConcurrency = configuration.clients * configuration.concurrency;
   const payloadLabel = configuration.sizes.map(formatPayloadSize).join(', ');
-  const payloadSuffix = configuration.sizes.length > 1 ? 's' : '';
-  const repeatSuffix = configuration.repeats > 1 ? 's' : '';
 
   const summaryItems = [
-    `**${summary.winsCount}** / **${summary.totalComparable}** benchmarks won`,
-    `**${Math.round(summary.averageSpeedBoost)}%** average speed improvement`,
-    `**${Math.round(summary.maximumSpeedBoost)}%** peak speed improvement`,
+    locale.benchmarksWon(summary.winsCount, summary.totalComparable),
+    locale.averageSpeedImprovement(Math.round(summary.averageSpeedBoost)),
+    locale.peakSpeedImprovement(Math.round(summary.maximumSpeedBoost)),
   ];
 
   const mainTableResult = buildMainTable(
@@ -507,6 +518,7 @@ export function generateMarkdownReport(
     baselineLibrary,
     solidisLibrary,
     maximumRatio,
+    locale,
   );
 
   const nonComparableTable = buildNonComparableTable(
@@ -515,19 +527,20 @@ export function generateMarkdownReport(
     solidisLibrary,
     mainTableResult.lastRank,
     maximumRatio,
+    locale,
   );
 
   const lines: string[] = [
     '<div align="center">',
     '',
-    `# ⚡ Solidis vs ${baselineLibrary} ⚡`,
+    `# ${locale.reportTitle(baselineLibrary)}`,
     '',
-    `<small>Generated on ${formatDateTime()} · ${process.platform} ${process.arch} · Node.js ${process.version}</small>`,
+    `<small>${locale.generatedOnPrefix} ${formatDateTime()} · ${process.platform} ${process.arch} · Node.js ${process.version}</small>`,
   ];
 
   if (summary.maximumSpeedBoost > 0) {
     lines.push(
-      `### Up to **${Math.round(summary.maximumSpeedBoost)}% faster** than ${baselineLibrary}! 🚀`,
+      `### ${locale.upToFaster(Math.round(summary.maximumSpeedBoost), baselineLibrary)}`,
       '',
     );
   }
@@ -538,7 +551,13 @@ export function generateMarkdownReport(
     '',
     `${summaryItems.join(' · ')}`,
     '',
-    `*${configuration.iterations.toLocaleString()} iterations × ${totalConcurrency} concurrency · ${payloadLabel} payload${payloadSuffix} · ${configuration.repeats} repeat${repeatSuffix}*`,
+    locale.subtitle(
+      configuration.iterations,
+      totalConcurrency,
+      payloadLabel,
+      configuration.sizes.length,
+      configuration.repeats,
+    ),
     '',
     mainTableResult.table,
     '',
@@ -546,9 +565,9 @@ export function generateMarkdownReport(
 
   if (nonComparableTable) {
     lines.push(
-      '### Non Strictly Comparable Benchmarks',
+      locale.nonComparableTitle,
       '',
-      '<sub>These benchmarks have library-specific behavior that prevents a strictly fair comparison.</sub>',
+      `<sub>${locale.nonComparableDescription}</sub>`,
       '',
       nonComparableTable,
       '',
@@ -556,44 +575,39 @@ export function generateMarkdownReport(
   }
 
   lines.push(
-    `<sub>Ranked by performance gain of \`${solidisLibrary}\` over \`${baselineLibrary}\` (baseline). Elapsed = median time across repeats.</sub>`,
+    `<sub>${locale.rankingFootnote(solidisLibrary, baselineLibrary)}</sub>`,
     '',
     '</div>',
     '',
     '<br/>',
     '',
-    '## 📊 Detailed Metrics',
+    locale.detailedMetricsTitle,
     '',
-    '<sub>All metrics per library: operations/s, commands/s, median elapsed time, and spread (coefficient of variation).</sub>',
+    `<sub>${locale.detailedMetricsDescription}</sub>`,
     '',
     '<details>',
-    '<summary>Click to expand detailed metrics table</summary>',
+    `<summary>${locale.expandDetailedMetrics}</summary>`,
     '',
-    buildDetailedMetricsTable(sortedGroups, solidisLibrary),
+    buildDetailedMetricsTable(sortedGroups, solidisLibrary, locale),
     '',
     '</details>',
     '',
     '---',
     '',
-    '## ⚙️ Configuration',
+    locale.configurationTitle,
     '',
     '<details>',
-    '<summary>Click to expand benchmark configuration</summary>',
+    `<summary>${locale.expandConfiguration}</summary>`,
     '',
-    buildConfigurationTable(configuration),
+    buildConfigurationTable(configuration, locale),
     '',
     '</details>',
     '',
     '---',
     '',
-    '## 📖 Methodology',
+    locale.methodologyTitle,
     '',
-    '- Each benchmark is run in an **isolated worker thread** to prevent GC and JIT cross-contamination',
-    '- Libraries are **alternated** between repeats to reduce ordering bias',
-    '- The Redis server is **flushed and settled** between each benchmark case',
-    '- Payloads use a **deterministic pseudo-random pool** shared by both libraries',
-    '- Elapsed time is the **median** across all repeat samples',
-    '- Spread is the **coefficient of variation** (σ / median × 100%)',
+    ...locale.methodologyItems.map((item) => `- ${item}`),
     '',
   );
 

--- a/scripts/benchmarks/shared/markdown/locales/en.ts
+++ b/scripts/benchmarks/shared/markdown/locales/en.ts
@@ -1,0 +1,103 @@
+import type { BenchmarkLocale } from './types.ts';
+
+function plural(count: number, singular: string): string {
+  return count === 1 ? singular : `${singular}s`;
+}
+
+export const en: BenchmarkLocale = {
+  sectionTitle: '## 📊 Benchmarks',
+
+  reportTitle: (baseline) => `⚡ Solidis vs ${baseline} ⚡`,
+  generatedOnPrefix: 'Generated on',
+  upToFaster: (percent, baseline) =>
+    `Up to **${percent}% faster** than ${baseline}! 🚀`,
+
+  benchmarksWon: (wins, total) => `**${wins}** / **${total}** benchmarks won`,
+  averageSpeedImprovement: (percent) =>
+    `**${percent}%** average speed improvement`,
+  peakSpeedImprovement: (percent) => `**${percent}%** peak speed improvement`,
+  subtitle: (iterations, concurrency, payloadLabel, payloadCount, repeats) =>
+    `*${iterations.toLocaleString()} iterations × ${concurrency.toLocaleString()} concurrency · ${payloadLabel} ${plural(payloadCount, 'payload')} · ${repeats.toLocaleString()} ${plural(repeats, 'repeat')}*`,
+
+  mainTableHeaders: {
+    benchmark: 'Benchmark',
+    commands: 'Commands',
+    difference: 'Difference',
+    performance: 'Performance',
+  },
+
+  noComparableResults: '*No comparable results.*',
+
+  nonComparableTitle: '### Non Strictly Comparable Benchmarks',
+  nonComparableDescription:
+    'These benchmarks have library-specific behavior that prevents a strictly fair comparison.',
+
+  rankingFootnote: (solidis, baseline) =>
+    `Ranked by performance gain of \`${solidis}\` over \`${baseline}\` (baseline). Elapsed = median time across repeats.`,
+
+  detailedMetricsTitle: '## 📊 Detailed Metrics',
+  detailedMetricsDescription:
+    'All metrics per library: operations/s, commands/s, median elapsed time, and spread (coefficient of variation).',
+  expandDetailedMetrics: 'Click to expand detailed metrics table',
+
+  detailedMetricsHeaders: {
+    benchmark: 'Benchmark',
+    library: 'Library',
+    opsPerSec: 'ops/s',
+    cmdsPerSec: 'cmds/s',
+    elapsed: 'Elapsed',
+    spread: 'Spread',
+  },
+
+  configurationTitle: '## ⚙️ Configuration',
+  expandConfiguration: 'Click to expand benchmark configuration',
+
+  configLabels: {
+    parameter: 'Parameter',
+    value: 'Value',
+    mode: 'Mode',
+    payloadSizes: 'Payload Sizes',
+    iterations: 'Iterations',
+    warmup: 'Warmup',
+    clients: 'Clients',
+    concurrencyPerClient: 'Concurrency / Client',
+    totalConcurrency: 'Total Concurrency',
+    repeats: 'Repeats',
+    cooldown: 'Cooldown',
+    platform: 'Platform',
+    nodeJs: 'Node.js',
+    date: 'Date',
+  },
+
+  methodologyTitle: '## 📖 Methodology',
+  methodologyItems: [
+    'Each benchmark is run in an **isolated worker thread** to prevent GC and JIT cross-contamination',
+    'Libraries are **alternated** between repeats to reduce ordering bias',
+    'The Redis server is **flushed and settled** between each benchmark case',
+    'Payloads use a **deterministic pseudo-random pool** shared by both libraries',
+    'Elapsed time is the **median** across all repeat samples',
+    'Spread is the **coefficient of variation** (σ / median × 100%)',
+  ],
+
+  operationDisplayNames: {
+    set: 'Set',
+    getBuffer: 'Get Buffer',
+    'hash:HSET+HGET+HGETALL': 'Hash Round-Trip',
+    'hash:HMSET+HMGET+HDEL': 'Hash Mutation',
+    'set:SADD+SISMEMBER+SMEMBERS': 'Set Read',
+    'set:SADD+SISMEMBER+SREM': 'Set Mutation',
+    'expire:SET+EXPIRE+TTL': 'Expire',
+    'nonTx:SETPX+GET': 'Non-Transaction',
+    'list:LPUSH+RPUSH+LRANGE': 'List Range',
+    'list:LPUSH+RPUSH+LPOP+RPOP+LLEN': 'List Mutation',
+    'counter:INCR+DECR': 'Counter',
+    'transaction:SET+EXPIRE+GET': 'Transaction',
+    'transactionMixed:SET+GET': 'Transaction Mixed',
+    'multiKey:MSET+MGET': 'Multi-Key',
+    'pipeline:SET+INCR+GET': 'Pipeline Mixed',
+    'stream:XADD+XRANGE+XLEN': 'Stream',
+    'zset:ZADD+ZRANGE+ZREM': 'Sorted Set',
+    'info:INFO+CONFIGGET': 'Info / Config',
+    'pubsub:PUBLISH+MESSAGE': 'Pub/Sub',
+  },
+};

--- a/scripts/benchmarks/shared/markdown/locales/index.ts
+++ b/scripts/benchmarks/shared/markdown/locales/index.ts
@@ -1,0 +1,26 @@
+import { en } from './en.ts';
+import { ko } from './ko.ts';
+
+import type { BenchmarkLocale } from './types.ts';
+
+const LOCALE_MAP: Record<string, BenchmarkLocale> = {
+  ko,
+};
+
+const LANG_CODE_PATTERN = /\.([a-z]{2}(?:-[a-z]{2})?)\.md$/i;
+
+export function resolveLocale(filename: string): BenchmarkLocale {
+  const match = LANG_CODE_PATTERN.exec(filename);
+
+  if (!match) {
+    return en;
+  }
+
+  const code = match[1].toLowerCase();
+
+  return LOCALE_MAP[code] ?? en;
+}
+
+export { en } from './en.ts';
+
+export type { BenchmarkLocale } from './types.ts';

--- a/scripts/benchmarks/shared/markdown/locales/ko.ts
+++ b/scripts/benchmarks/shared/markdown/locales/ko.ts
@@ -1,0 +1,99 @@
+import type { BenchmarkLocale } from './types.ts';
+
+export const ko: BenchmarkLocale = {
+  sectionTitle: '## 📊 벤치마크',
+
+  reportTitle: (baseline) => `⚡ Solidis vs ${baseline} ⚡`,
+  generatedOnPrefix: '측정일',
+  upToFaster: (percent, baseline) =>
+    `${baseline} 대비 최대 **${percent}% 빠릅니다**! 🚀`,
+
+  benchmarksWon: (wins, total) =>
+    `**${total}**개 중 **${wins}**개 벤치마크 우위`,
+  averageSpeedImprovement: (percent) => `평균 **${percent}%** 성능 향상`,
+  peakSpeedImprovement: (percent) => `최대 **${percent}%** 성능 향상`,
+  subtitle: (iterations, concurrency, payloadLabel, _payloadCount, repeats) =>
+    `*${iterations.toLocaleString()}번 반복 × ${concurrency.toLocaleString()} 동시 실행 · ${payloadLabel} 페이로드 · ${repeats.toLocaleString()}회 측정*`,
+
+  mainTableHeaders: {
+    benchmark: '벤치마크',
+    commands: '명령어',
+    difference: '차이',
+    performance: '성능',
+  },
+
+  noComparableResults: '*비교 가능한 결과가 없습니다.*',
+
+  nonComparableTitle: '### 엄격한 비교가 불가능한 벤치마크',
+  nonComparableDescription:
+    '라이브러리별 고유 동작으로 인해 엄밀한 비교가 어려운 벤치마크입니다.',
+
+  rankingFootnote: (solidis, baseline) =>
+    `\`${solidis}\`의 \`${baseline}\` (기준) 대비 성능 향상률 순으로 정렬. 소요 시간 = 반복 측정의 중앙값.`,
+
+  detailedMetricsTitle: '## 📊 상세 지표',
+  detailedMetricsDescription:
+    '라이브러리별 전체 지표: 초당 작업 수, 초당 명령 수, 소요 시간 중앙값, 분산 (변동 계수).',
+  expandDetailedMetrics: '상세 지표 테이블 펼치기',
+
+  detailedMetricsHeaders: {
+    benchmark: '벤치마크',
+    library: '라이브러리',
+    opsPerSec: 'ops/s',
+    cmdsPerSec: 'cmds/s',
+    elapsed: '소요 시간',
+    spread: '분산',
+  },
+
+  configurationTitle: '## ⚙️ 설정',
+  expandConfiguration: '벤치마크 설정 펼치기',
+
+  configLabels: {
+    parameter: '항목',
+    value: '값',
+    mode: '모드',
+    payloadSizes: '페이로드 크기',
+    iterations: '반복 횟수',
+    warmup: '워밍업',
+    clients: '클라이언트 수',
+    concurrencyPerClient: '클라이언트당 동시 실행',
+    totalConcurrency: '총 동시 실행',
+    repeats: '측정 횟수',
+    cooldown: '쿨다운',
+    platform: '플랫폼',
+    nodeJs: 'Node.js',
+    date: '날짜',
+  },
+
+  methodologyTitle: '## 📖 측정 방법론',
+  methodologyItems: [
+    '각 벤치마크는 GC 및 JIT 간섭을 방지하기 위해 **격리된 워커 스레드**에서 실행됩니다',
+    '순서 편향을 줄이기 위해 반복 측정 시 라이브러리를 **번갈아 실행**합니다',
+    'Redis 서버는 각 벤치마크 케이스 사이에 **초기화 및 안정화**됩니다',
+    '페이로드는 두 라이브러리가 공유하는 **결정론적 의사 난수 풀**을 사용합니다',
+    '소요 시간은 전체 반복 샘플의 **중앙값**입니다',
+    '분산은 **변동 계수** (σ / 중앙값 × 100%)입니다',
+  ],
+
+  operationDisplayNames: {
+    set: 'Set',
+    getBuffer: 'Get Buffer',
+    'hash:HSET+HGET+HGETALL': 'Hash 왕복',
+    'hash:HMSET+HMGET+HDEL': 'Hash 변경',
+    'set:SADD+SISMEMBER+SMEMBERS': 'Set 조회',
+    'set:SADD+SISMEMBER+SREM': 'Set 변경',
+    'expire:SET+EXPIRE+TTL': 'Expire',
+    'nonTx:SETPX+GET': '비트랜잭션',
+    'list:LPUSH+RPUSH+LRANGE': 'List 범위',
+    'list:LPUSH+RPUSH+LPOP+RPOP+LLEN': 'List 변경',
+    'counter:INCR+DECR': 'Counter',
+    'transaction:SET+EXPIRE+GET': '트랜잭션',
+    'transactionMixed:SET+GET': '트랜잭션 혼합',
+    'multiKey:MSET+MGET': 'Multi-Key',
+    'pipeline:SET+INCR+GET': '파이프라인 혼합',
+    'stream:XADD+XRANGE+XLEN': 'Stream',
+    'zset:ZADD+ZRANGE+ZREM': 'Sorted Set',
+    'info:INFO+CONFIGGET': 'Info / Config',
+    'pubsub:PUBLISH+MESSAGE': 'Pub/Sub',
+  },
+};

--- a/scripts/benchmarks/shared/markdown/locales/types.ts
+++ b/scripts/benchmarks/shared/markdown/locales/types.ts
@@ -1,0 +1,70 @@
+export interface BenchmarkLocale {
+  sectionTitle: string;
+
+  reportTitle(baseline: string): string;
+  generatedOnPrefix: string;
+  upToFaster(percent: number, baseline: string): string;
+
+  benchmarksWon(wins: number, total: number): string;
+  averageSpeedImprovement(percent: number): string;
+  peakSpeedImprovement(percent: number): string;
+  subtitle(
+    iterations: number,
+    concurrency: number,
+    payloadLabel: string,
+    payloadCount: number,
+    repeats: number,
+  ): string;
+
+  mainTableHeaders: {
+    benchmark: string;
+    commands: string;
+    difference: string;
+    performance: string;
+  };
+
+  noComparableResults: string;
+
+  nonComparableTitle: string;
+  nonComparableDescription: string;
+
+  rankingFootnote(solidis: string, baseline: string): string;
+
+  detailedMetricsTitle: string;
+  detailedMetricsDescription: string;
+  expandDetailedMetrics: string;
+
+  detailedMetricsHeaders: {
+    benchmark: string;
+    library: string;
+    opsPerSec: string;
+    cmdsPerSec: string;
+    elapsed: string;
+    spread: string;
+  };
+
+  configurationTitle: string;
+  expandConfiguration: string;
+
+  configLabels: {
+    parameter: string;
+    value: string;
+    mode: string;
+    payloadSizes: string;
+    iterations: string;
+    warmup: string;
+    clients: string;
+    concurrencyPerClient: string;
+    totalConcurrency: string;
+    repeats: string;
+    cooldown: string;
+    platform: string;
+    nodeJs: string;
+    date: string;
+  };
+
+  methodologyTitle: string;
+  methodologyItems: string[];
+
+  operationDisplayNames: Record<string, string>;
+}

--- a/scripts/benchmarks/shared/markdown/merge.ts
+++ b/scripts/benchmarks/shared/markdown/merge.ts
@@ -8,6 +8,7 @@ import { loadSnapshot, mergeSnapshots } from './snapshot.ts';
 const processArguments = process.argv.slice(2);
 const snapshotPaths: string[] = [];
 let outputPath = './benchmark.md';
+let snapshotOutputPath: string | undefined;
 
 for (let index = 0; index < processArguments.length; index += 1) {
   const argument = processArguments[index];
@@ -22,6 +23,16 @@ for (let index = 0; index < processArguments.length; index += 1) {
 
     outputPath = nextValue;
     index += 1;
+  } else if (argument === '--snapshot' || argument === '-s') {
+    const nextValue = processArguments[index + 1];
+
+    if (!nextValue) {
+      console.error('Missing value for --snapshot');
+      process.exit(1);
+    }
+
+    snapshotOutputPath = nextValue;
+    index += 1;
   } else {
     snapshotPaths.push(argument);
   }
@@ -29,7 +40,7 @@ for (let index = 0; index < processArguments.length; index += 1) {
 
 if (snapshotPaths.length === 0) {
   console.error(
-    'Usage: benchmark:merge <file1.benchmark> <file2.benchmark> ... [-o output.md]',
+    'Usage: benchmark:merge <file1.benchmark> <file2.benchmark> ... [-o output.md] [-s merged.benchmark]',
   );
   process.exit(1);
 }
@@ -49,6 +60,17 @@ const markdown = generateMarkdownReport(
 const resolvedOutputPath = resolve(outputPath);
 
 await writeFile(resolvedOutputPath, markdown, 'utf-8');
+
+if (snapshotOutputPath) {
+  const resolvedSnapshotPath = resolve(snapshotOutputPath);
+
+  await writeFile(
+    resolvedSnapshotPath,
+    JSON.stringify(merged, null, 2),
+    'utf-8',
+  );
+  console.log(`  Snapshot: ${resolvedSnapshotPath}`);
+}
 
 console.log(
   `Merged ${snapshotPaths.length} snapshot(s) from suite "${merged.suiteName}"`,

--- a/scripts/benchmarks/shared/markdown/replace.readme.ts
+++ b/scripts/benchmarks/shared/markdown/replace.readme.ts
@@ -1,6 +1,11 @@
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+import { deserializeConfig } from '../configuration.ts';
+import { generateMarkdownReport } from './index.ts';
+import { resolveLocale } from './locales/index.ts';
+import { loadSnapshot, mergeSnapshots } from './snapshot.ts';
+
 const MARKER = '<div id="benchmark">';
 const DIV_OPEN = /<div[\s>]/gi;
 const DIV_CLOSE = /<\/div>/gi;
@@ -40,12 +45,18 @@ function findClosingDiv(content: string, afterIndex: number): number {
 const processArguments = process.argv.slice(2);
 
 if (processArguments.length < 1) {
-  console.error('Usage: benchmark:replace:readme <benchmark-report.md>');
+  console.error(
+    'Usage: benchmark:replace:readme <snapshot.benchmark> [snapshot2.benchmark ...]',
+  );
   process.exit(1);
 }
 
-const reportPath = resolve(processArguments[0]);
-const report = await readFile(reportPath, 'utf-8');
+const snapshotPaths = processArguments;
+const snapshots = await Promise.all(
+  snapshotPaths.map((path) => loadSnapshot(path)),
+);
+const merged = mergeSnapshots(snapshots);
+const configuration = deserializeConfig(merged.configuration);
 
 const projectRoot = resolve('.');
 const entries = await readdir(projectRoot);
@@ -81,7 +92,15 @@ for (const readmeFile of readmeFiles) {
     continue;
   }
 
-  const section = `${MARKER}\n\n## 📊 Benchmarks\n\n${report.trimEnd()}\n\n</div>`;
+  const locale = resolveLocale(readmeFile);
+  const report = generateMarkdownReport(
+    merged.results,
+    merged.baselineLibrary,
+    configuration,
+    locale,
+  );
+
+  const section = `${MARKER}\n\n${locale.sectionTitle}\n\n${report.trimEnd()}\n\n</div>`;
 
   const updated =
     readme.slice(0, startIndex) +
@@ -90,7 +109,10 @@ for (const readmeFile of readmeFiles) {
 
   await writeFile(readmePath, updated, 'utf-8');
   updatedCount += 1;
-  console.log(`Updated ${readmeFile}`);
+
+  const langCode =
+    readmeFile.match(/\.([a-z]{2}(?:-[a-z]{2})?)\.md$/i)?.[1] ?? 'en';
+  console.log(`Updated ${readmeFile} (locale: ${langCode})`);
 }
 
 console.log(`Done: ${updatedCount} file(s) updated.`);


### PR DESCRIPTION
## Summary

- Add locale system for benchmark markdown report generation (`BenchmarkLocale` interface + `en`, `ko` implementations)
- `replace.readme.ts` now accepts snapshot files directly and generates per-locale reports (e.g. `README.md` → English, `README.ko.md` → Korean)
- `merge.ts` supports `--snapshot` / `-s` flag to output merged snapshot alongside markdown
- Fix inconsistent number formatting in subtitle (all numeric values now use `toLocaleString()`)

## Changes

- **New**: `scripts/benchmarks/shared/markdown/locales/` - locale types, English (`en.ts`), Korean (`ko.ts`), resolver (`index.ts`)
- **Modified**: `markdown/index.ts` - `generateMarkdownReport` accepts optional `BenchmarkLocale` param (defaults to `en`)
- **Modified**: `replace.readme.ts` - accepts snapshot input instead of markdown; resolves locale per README file
- **Modified**: `merge.ts` - added `--snapshot` / `-s` output option
- **Modified**: `benchmark.yml` - updated CI pipeline to pass merged snapshot to `replace:readme`