### PR TITLE
fix: resolve async race conditions in connection cleanup and reply chunk processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vcms-io/solidis",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vcms-io/solidis",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcms-io/solidis",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Jay Lee <jay@vendit.co.kr>",
   "description": "High-performance, SOLID-structured RESP client for Redis and other RESP-compatible servers",
   "repository": {

--- a/scripts/tests/client/resilience/003.cleanup-race.test.ts
+++ b/scripts/tests/client/resilience/003.cleanup-race.test.ts
@@ -1,0 +1,105 @@
+/** Cleanup race: deferred end-callback in cleanup() targets the wrong socket during reconnection. */
+
+import { afterEach, describe, it } from 'node:test';
+
+import { SolidisFeaturedClient } from '../../../../sources/client/featured.ts';
+import {
+  closeClient,
+  createClient,
+  MockRedisServer,
+  mockClientOptions,
+  waitFor,
+} from '../../utils/index.ts';
+
+import type { FeaturedClient } from '../../utils/index.ts';
+
+describe('cleanup-race', () => {
+  const mockClients: FeaturedClient[] = [];
+  const mockServers: MockRedisServer[] = [];
+
+  const trackMockClient = (client: FeaturedClient): FeaturedClient => {
+    client.on('error', () => {});
+    mockClients.push(client);
+
+    return client;
+  };
+
+  const startMockServer = async (): Promise<MockRedisServer> => {
+    const server = new MockRedisServer();
+    mockServers.push(server);
+    await server.listen();
+
+    return server;
+  };
+
+  afterEach(async () => {
+    for (const client of mockClients.splice(0)) {
+      client.quit();
+    }
+
+    for (const server of mockServers.splice(0)) {
+      await server.close();
+    }
+  });
+
+  it('reconnects after an abrupt mock-server disconnect with no retries', async () => {
+    const server = await startMockServer();
+
+    const client = trackMockClient(
+      new SolidisFeaturedClient(
+        mockClientOptions(server.port, {
+          autoReconnect: true,
+          maxConnectionRetries: 0,
+          connectionTimeout: 2000,
+        }),
+      ),
+    );
+
+    await client.connect();
+
+    let reconnected = false;
+
+    client.on('ready', () => {
+      reconnected = true;
+    });
+
+    server.destroySockets();
+
+    await waitFor(() => reconnected, {
+      timeout: 3000,
+      interval: 50,
+      description: 'reconnect after abrupt mock disconnect',
+    });
+  });
+
+  it('reconnects after a forced CLIENT KILL with no retries', async () => {
+    const client = await createClient({
+      autoReconnect: true,
+      maxConnectionRetries: 0,
+      connectionTimeout: 2000,
+    });
+
+    const killer = await createClient();
+
+    try {
+      const clientId = await client.clientId();
+
+      let reconnected = false;
+
+      client.on('ready', () => {
+        reconnected = true;
+      });
+
+      await killer.clientKill(clientId);
+
+      await waitFor(() => reconnected, {
+        timeout: 3000,
+        interval: 50,
+        description: 'reconnect after CLIENT KILL',
+      });
+    } finally {
+      await closeClient(killer);
+      await closeClient(client);
+    }
+  });
+});

--- a/scripts/tests/client/resilience/004.reply-race.test.ts
+++ b/scripts/tests/client/resilience/004.reply-race.test.ts
@@ -1,0 +1,163 @@
+/** Reply race: fire-and-forget dispatch in resolveRepliesInChunks desynchronises reply correlation. */
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { SolidisFeaturedClient } from '../../../../sources/client/featured.ts';
+import { MockRedisServer, mockClientOptions } from '../../utils/index.ts';
+
+import type { FeaturedClient } from '../../utils/index.ts';
+
+describe('reply-race', () => {
+  const mockClients: FeaturedClient[] = [];
+  const mockServers: MockRedisServer[] = [];
+
+  const trackMockClient = (client: FeaturedClient): FeaturedClient => {
+    client.on('error', () => {});
+    mockClients.push(client);
+
+    return client;
+  };
+
+  const startMockServer = async (): Promise<MockRedisServer> => {
+    const server = new MockRedisServer();
+    mockServers.push(server);
+    await server.listen();
+
+    return server;
+  };
+
+  afterEach(async () => {
+    for (const client of mockClients.splice(0)) {
+      client.quit();
+    }
+
+    for (const server of mockServers.splice(0)) {
+      await server.close();
+    }
+  });
+
+  it('attributes every reply to the correct pipeline across chunked processing', async () => {
+    const server = await startMockServer();
+
+    const commandCount = 200;
+
+    let responded = false;
+
+    server.onData((socket) => {
+      if (responded) {
+        return;
+      }
+
+      responded = true;
+
+      socket.setNoDelay(true);
+
+      const repliesForPrimary = '+a\r\n'.repeat(commandCount);
+
+      socket.write(Buffer.from(repliesForPrimary, 'latin1'));
+
+      setTimeout(() => {
+        socket.write(Buffer.from('+b\r\n', 'latin1'));
+      }, 0);
+    });
+
+    const client = trackMockClient(
+      new SolidisFeaturedClient(
+        mockClientOptions(server.port, {
+          maxProcessRepliesPerChunk: 1,
+          maxProcessReplyBytesPerChunk: 12,
+          maxCommandsPerPipeline: commandCount,
+          commandTimeout: 10000,
+        }),
+      ),
+    );
+
+    await client.connect();
+
+    const primaryCommands = Array.from({ length: commandCount }, () => [
+      'ECHO',
+      'a',
+    ]);
+    const secondaryCommands = [['ECHO', 'b']];
+
+    const primaryPipeline = client.send(primaryCommands);
+    const secondaryPipeline = client.send(secondaryCommands);
+
+    const [primaryReplies, secondaryReplies] = await Promise.all([
+      primaryPipeline,
+      secondaryPipeline,
+    ]);
+
+    assert.strictEqual(primaryReplies.length, commandCount);
+
+    assert.ok(
+      primaryReplies.every((reply) => reply.length === 1 && reply[0] === 'a'),
+      'every reply in the primary pipeline must be the value sent by its own command',
+    );
+
+    assert.deepStrictEqual(secondaryReplies, [['b']]);
+  });
+
+  it('preserves reply order under a different byte-chunk alignment', async () => {
+    const server = await startMockServer();
+
+    const commandCount = 100;
+
+    let responded = false;
+
+    server.onData((socket) => {
+      if (responded) {
+        return;
+      }
+
+      responded = true;
+
+      socket.setNoDelay(true);
+
+      const repliesForPrimary = '+x\r\n'.repeat(commandCount);
+
+      socket.write(Buffer.from(repliesForPrimary, 'latin1'));
+
+      setTimeout(() => {
+        socket.write(Buffer.from('+y\r\n', 'latin1'));
+      }, 0);
+    });
+
+    const client = trackMockClient(
+      new SolidisFeaturedClient(
+        mockClientOptions(server.port, {
+          maxProcessRepliesPerChunk: 1,
+          maxProcessReplyBytesPerChunk: 14,
+          maxCommandsPerPipeline: commandCount,
+          commandTimeout: 10000,
+        }),
+      ),
+    );
+
+    await client.connect();
+
+    const primaryCommands = Array.from({ length: commandCount }, () => [
+      'ECHO',
+      'x',
+    ]);
+    const secondaryCommands = [['ECHO', 'y']];
+
+    const primaryPipeline = client.send(primaryCommands);
+    const secondaryPipeline = client.send(secondaryCommands);
+
+    const [primaryReplies, secondaryReplies] = await Promise.all([
+      primaryPipeline,
+      secondaryPipeline,
+    ]);
+
+    assert.strictEqual(primaryReplies.length, commandCount);
+
+    assert.ok(
+      primaryReplies.every((reply) => reply.length === 1 && reply[0] === 'x'),
+      'every reply in the primary pipeline must be the value sent by its own command',
+    );
+
+    assert.deepStrictEqual(secondaryReplies, [['y']]);
+  });
+});

--- a/sources/modules/connection.ts
+++ b/sources/modules/connection.ts
@@ -82,14 +82,19 @@ export class SolidisConnection extends EventEmitter {
       this.#connectTimeout = null;
     }
 
-    if (this.#socket) {
-      this.#socket.end(() => {
-        this.#socket?.removeAllListeners();
-        this.#socket?.destroy();
-        this.#socket?.unref();
-        this.#socket = null;
-      });
+    const socket = this.#socket;
+
+    if (!socket) {
+      return;
     }
+
+    this.#socket = null;
+
+    socket.end(() => {
+      socket.removeAllListeners();
+      socket.destroy();
+      socket.unref();
+    });
   }
 
   public quit() {
@@ -100,6 +105,10 @@ export class SolidisConnection extends EventEmitter {
   }
 
   public reset() {
+    if (this.#connectLock) {
+      return;
+    }
+
     const socket = this.#socket;
 
     if (!socket) {

--- a/sources/modules/requester.ts
+++ b/sources/modules/requester.ts
@@ -477,7 +477,7 @@ export class SolidisRequester {
         return;
       }
 
-      this.#resolveRepliesInChunks(parsedReplies, maxReplyCount, emit);
+      await this.#resolveRepliesInChunks(parsedReplies, maxReplyCount, emit);
 
       if (shouldYield) {
         await new Promise<void>((resolve) => setImmediate(resolve));
@@ -520,7 +520,7 @@ export class SolidisRequester {
     }
   }
 
-  #resolveRepliesInChunks(
+  async #resolveRepliesInChunks(
     parsedReplies: SolidisData[],
     maxChunkSize: number,
     emit: SolidisClientEventHandlers['emit'],
@@ -538,13 +538,15 @@ export class SolidisRequester {
     }
 
     for (let index = 0; index < length; index += maxChunkSize) {
-      setImmediate(() => {
-        this.#resolveReplies(
-          parsedReplies,
-          emit,
-          index,
-          Math.min(index + maxChunkSize, length),
-        );
+      const start = index;
+      const end = Math.min(index + maxChunkSize, length);
+
+      await new Promise<void>((resolve) => {
+        setImmediate(() => {
+          this.#resolveReplies(parsedReplies, emit, start, end);
+
+          resolve();
+        });
       });
     }
   }


### PR DESCRIPTION
## Summary

- Fix a socket reference race in `connection.cleanup()` where the deferred `end` callback operated on `this.#socket` instead of a captured local reference, causing it to destroy a newly created socket during reconnection
- Fix a secondary race path in `connection.reset()` where fault recovery could destroy a socket that `#tryBackgroundReconnect()` had already replaced, by guarding against an active `#connectLock`
- Fix a reply correlation race in `requester.#resolveRepliesInChunks()` where fire-and-forget `setImmediate` dispatch allowed a subsequent `#processReplies` invocation to resolve replies against the wrong pipeline's pending commands

## Changes

### `sources/modules/connection.ts`

- `cleanup()`: Capture `this.#socket` into a local variable and nullify `this.#socket` synchronously before calling `socket.end()`, so the deferred callback always targets the original socket
- `reset()`: Early-return when `this.#connectLock` is held, preventing interference with an ongoing reconnection

### `sources/modules/requester.ts`

- `#resolveRepliesInChunks()`: Convert to `async` and `await` each `setImmediate`-wrapped chunk resolution, ensuring all replies are fully dispatched before `#processReplies` releases the reply lock
- `#processReplies()`: `await` the now-async `#resolveRepliesInChunks()` call

### Tests

- Add `003.cleanup-race.test.ts`: Two scenarios verifying reconnection stability after abrupt server disconnect and forced client kill
- Add `004.reply-race.test.ts`: Two scenarios verifying correct reply-to-pipeline correlation under chunked processing with different byte-chunk alignments

## Performance Impact

- **`cleanup()` / `reset()`**: Zero impact — rare disconnect/recovery path only
- **`#resolveRepliesInChunks()`**: Zero impact for the common case (replies ≤ `maxProcessRepliesPerChunk`). For batches exceeding 4,096 replies, sequential `setImmediate` yields replace fire-and-forget scheduling — this matches the original design intent of event loop yielding during large reply processing