### PR TITLE
feat: add llms.txt, robots and sitemap for AI agent discoverability

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Solidis",
+  "description": "The fastest Redis & Valkey client for Node.js. Zero dependencies, full RESP2/RESP3 support, TypeScript-first.",
+  "folders": [],
+  "excludeFolders": ["website", "sources", "scripts", "assets"],
+  "excludeFiles": ["README.ko.md"],
+  "rules": [
+    "Install with: npm install @vcms-io/solidis",
+    "Import SolidisFeaturedClient from '@vcms-io/solidis/featured' for the full Redis command set",
+    "For minimal bundle size, import SolidisClient from '@vcms-io/solidis' and add only needed commands via .extend()",
+    "Solidis has zero dependencies — do not add other Redis client libraries alongside it",
+    "All commands return Promises and are fully typed; prefer TypeScript strict mode"
+  ]
+}

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -8,6 +8,7 @@ import { Navbar } from '@/components/navbar';
 import { I18nProvider } from '@/lib/i18n-context';
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://solidis.vcms.io'),
   title: 'Solidis | Zero-dependency RESP client for Redis',
   description:
     'The fastest Redis client for Node.js. Zero dependencies, full RESP2/RESP3 support, TypeScript-first. Up to 2x faster than ioredis.',

--- a/website/app/robots.ts
+++ b/website/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: 'https://solidis.vcms.io/sitemap.xml',
+  };
+}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+
+const routes = [
+  '',
+  '/getting-started',
+  '/api-reference',
+  '/architecture',
+  '/benchmarks',
+  '/faq',
+  '/contributing',
+  '/updates',
+  '/tutorials',
+  '/tutorials/session-store',
+  '/tutorials/cache-layer',
+  '/tutorials/rate-limiting',
+  '/tutorials/chat-app',
+  '/tutorials/distributed-locking',
+  '/tutorials/job-queue',
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return routes.map((route) => ({
+    url: `https://solidis.vcms.io${route}`,
+  }));
+}

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,34 @@
+# Solidis
+
+> The fastest Redis & Valkey client for Node.js. Zero dependencies, full RESP2/RESP3 support, TypeScript-first, 2x+ faster than ioredis, < 29KB minimum bundle.
+
+Solidis is a zero-dependency RESP (Redis Serialization Protocol) client for Node.js, published on npm as `@vcms-io/solidis`. It ships 383 commands, dual ESM/CJS builds, and two clients: the batteries-included `SolidisFeaturedClient` and the tree-shakable `SolidisClient` with `.extend()` for minimal bundles.
+
+## Docs
+
+- [Getting Started](https://solidis.vcms.io/getting-started): Installation, client setup, and first commands
+- [API Reference](https://solidis.vcms.io/api-reference): Classes, methods, and interfaces
+- [Architecture](https://solidis.vcms.io/architecture): Internal structure and SOLID design principles
+- [Benchmarks](https://solidis.vcms.io/benchmarks): Performance comparisons against ioredis
+- [FAQ](https://solidis.vcms.io/faq): Common questions and answers
+
+## Tutorials
+
+- [Session Store](https://solidis.vcms.io/tutorials/session-store): Redis-based session store for web applications
+- [Cache Layer](https://solidis.vcms.io/tutorials/cache-layer): High-performance caching for database queries and API calls
+- [Rate Limiting](https://solidis.vcms.io/tutorials/rate-limiting): Redis-based rate limiting strategies
+- [Real-time Chat](https://solidis.vcms.io/tutorials/chat-app): Pub/Sub chat with WebSockets
+- [Distributed Locking](https://solidis.vcms.io/tutorials/distributed-locking): Coordinating operations across processes
+- [Job Queue](https://solidis.vcms.io/tutorials/job-queue): Background job processing with Redis lists
+
+## Source
+
+- [Full documentation (README, Markdown)](https://raw.githubusercontent.com/vcms-io/solidis/main/README.md): Quick start, features, configuration, architecture, and extensions
+- [GitHub repository](https://github.com/vcms-io/solidis)
+- [npm package](https://www.npmjs.com/package/@vcms-io/solidis)
+
+## Optional
+
+- [Contributing](https://solidis.vcms.io/contributing): How to contribute to Solidis
+- [Product Updates](https://solidis.vcms.io/updates): Release notes and changelog
+- [Documentation in Korean (README.ko.md, Markdown)](https://raw.githubusercontent.com/vcms-io/solidis/main/README.ko.md)


### PR DESCRIPTION
## Summary

Makes the website and repo agent-native so LLMs and coding agents can discover and navigate Solidis documentation:

- **`/llms.txt`** ([llmstxt.org](https://llmstxt.org) format): curated index of docs, tutorials, and raw Markdown sources (README / README.ko) for LLM consumption
- **`/robots.txt`** via Next.js metadata route (`app/robots.ts`): allows all crawlers, references the sitemap
- **`/sitemap.xml`** via Next.js metadata route (`app/sitemap.ts`): all static routes
- **`metadataBase`** in root layout for canonical URL resolution
- **`context7.json`** (repo root): [Context7](https://context7.com) indexing config — scopes parsing to the English README, excludes source/website/scripts noise, and ships usage rules (featured vs tree-shakable client, zero-dependency constraint) that AI assistants receive alongside doc snippets

## Notes

- Instead of duplicating page content into an `llms-full.txt` (which would drift from the TSX/i18n sources), `llms.txt` links to the raw GitHub README as the full Markdown documentation.
- `README.ko.md` is excluded from Context7 parsing to avoid duplicate snippets in mixed languages; the Korean docs remain linked from `llms.txt`.
- Verified with `next build`: `/robots.txt` and `/sitemap.xml` render as static routes, TypeScript passes, biome check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)